### PR TITLE
Removed trailing whitespace from entries in axis.txt

### DIFF
--- a/Discovery/Web_Content/axis.txt
+++ b/Discovery/Web_Content/axis.txt
@@ -1,12 +1,12 @@
 *.jws
 AdminServlet
 AxisServlet
-EchoHeaders.jws         
+EchoHeaders.jws
 SOAPMonitor
-StockQuoteService.jws  
-fingerprint.jsp  
-happyaxis.jsp    
-i18nLib.jsp  
+StockQuoteService.jws
+fingerprint.jsp
+happyaxis.jsp
+i18nLib.jsp
 index.html
 index.jsp
 index.jws


### PR DESCRIPTION
Requesting "/happyaxis.jsp     HTTP/1.1" (note the extra whitespace) could cause issue.