### PR TITLE
Support for CVE-2007-1860 mod_jk double encoding

### DIFF
--- a/Discovery/Web_Content/tomcat.txt
+++ b/Discovery/Web_Content/tomcat.txt
@@ -21,6 +21,9 @@ examples/servlet/org.apache.catalina.servlets.WebdavServlet/jsp/snp/snoop.jsp
 examples/servlet/org.apache.catalina.servlets.WebdavServlet/jsp/source.jsp
 examples/servlet/snoop
 examples/servlets/index.html
+examples/../manager/html
+examples/%2e%2e/manager/html
+examples/%252e%252e/manager/html
 host-manager
 host-manager/add
 host-manager/host-manager.xml


### PR DESCRIPTION
Added paths that will check access control bypass using double encoding (CVE-2007-1860) that could allow a remote user to access Tomcat's administration panel.
Based on the scenario demonstrated on https://pentesterlab.com/exercises/cve-2007-1860/course