### PR TITLE
Add .pht extention

### DIFF
--- a/Miscellaneous/web-extensions.txt
+++ b/Miscellaneous/web-extensions.txt
@@ -16,6 +16,7 @@
 .log
 .mdb
 .nsf
+.pcap
 .php
 .php2
 .php3
@@ -23,14 +24,14 @@
 .php5
 .php6
 .php7
-.phtml
 .phps
+.pht
+.phtml
 .pl
 .reg
 .sh
 .shtml
 .sql
+.swf
 .txt
 .xml
-.swf
-.pcap


### PR DESCRIPTION
Adds the .pht PHP extension as used in the latest Joomla exploit - https://github.com/XiphosResearch/exploits/tree/master/Joomraa

Also sorted the list.
