### PR TITLE
Added SAP ICM auth guest-login bypass URL

### DIFF
--- a/Discovery/Web_Content/sap.txt
+++ b/Discovery/Web_Content/sap.txt
@@ -183,6 +183,7 @@ sap/
 sap/IStest
 sap/admin
 sap/admin/default.html
+sap/admin/index.html
 sap/ap
 sap/bc
 sap/bc/


### PR DESCRIPTION
Added string sap/admin/index.html that bypasses the guest authentication for the ICM Administration interface if not configured properly. Related to the URL sap/admin/default.html string which requires authentication.