### PR TITLE
Files flagged as virus/malware

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:latest
+LABEL maintainer "Peter Benjamin <petermbenjamin@gmail.com>"
+WORKDIR /seclists/
+RUN apk --no-cache add git \
+    && git clone https://github.com/danielmiessler/seclists.git /seclists/
+CMD ["sh"]
+


### PR DESCRIPTION
First, thank you for all the effort that went into creating these lists & the work that goes into maintaining it.

I just wanted to report that Symantec Endpoint Protection (SEP) detects & blocks some files in this repo as malware or virus.

![seclists-av](https://user-images.githubusercontent.com/6811830/31414448-d2263e5a-add2-11e7-93bd-4d3dad79727a.png)

I have mitigated/worked around this problem locally by building a docker image with this repo baked in `/seclists/` path.

I have taken the liberty to contribute this as PR, if the project owner/contributors/maintainers think this contribution is worth it.