### PR TITLE
Add PHPSESSID in the list of session ids

### DIFF
--- a/Miscellaneous/sessionid.txt
+++ b/Miscellaneous/sessionid.txt
@@ -8,3 +8,4 @@ sessid
 sid
 viewstate
 zenid
+PHPSESSID


### PR DESCRIPTION
The default session id name for PHP which is the most widely used server-side language is `PHPSESSID`.

http://php.net/manual/en/session.configuration.php#ini.session.name