### PR TITLE
Update default-passwords.csv

### DIFF
--- a/Passwords/Default-Credentials/default-passwords.csv
+++ b/Passwords/Default-Credentials/default-passwords.csv
@@ -578,6 +578,7 @@ Colubris Networks,admin,admin,
 Colubris,admin,admin,
 Comcast Home Networking,comcast,<BLANK>,
 Comcast SMC,cusadmin,highspeed,
+Comcast SMC,cusadmin,CantTouchThis,
 Comersus,admin,dmr99,
 "Comodo Group, Inc",mydlp,mydlp,https://www.mydlp.com/wp-content/uploads/Comodo_MyDLP_Admin_guide.pdf
 Compaq,<BLANK>,,use ALT+G at boot to reset config


### PR DESCRIPTION
Default password for `cusadmin` didn't work so I looked in the [documentation](https://business.comcast.com/help-and-support/internet/setup-manage-comcast-wifi-business-wireless-gateway/) and they suggested to try between two passwords.

The second one worked.