### PR TITLE
added wordlist for Spring Boot (Actuator)

### DIFF
--- a/Discovery/Web-Content/spring-boot.txt
+++ b/Discovery/Web-Content/spring-boot.txt
@@ -1,0 +1,13 @@
+trace
+health
+loggers
+metrics
+autoconfig
+heapdump
+env
+info
+dump
+configprops
+mappings
+auditevents
+beans


### PR DESCRIPTION
I've added a wordlist for URLs that become available when Spring Boot applications are deployed with Actuator (which exposes metrics and much more).