### PR TITLE
Add Shopware common sensitive files wordlist.

### DIFF
--- a/Discovery/Web-Content/CMS/shopware.txt
+++ b/Discovery/Web-Content/CMS/shopware.txt
@@ -1,0 +1,5 @@
+/backend/
+composer.json
+composer.lock
+config.php.dist
+phpinfo.php


### PR DESCRIPTION
Shopware is open source e-commerce software 
https://github.com/shopware/shopware 
Shopware wordlist was not presented in this directory. The file required improvements and should be expanded