### PR TITLE
Add Wordpress, Django, Flask and Shopware login pages

### DIFF
--- a/Discovery/Web-Content/Logins.fuzz.txt
+++ b/Discovery/Web-Content/Logins.fuzz.txt
@@ -7,6 +7,7 @@
 /admin.pl
 /admin.py
 /admin.rb
+/admin/
 /administrator
 /administrator.asp
 /administrator.aspx
@@ -18,11 +19,14 @@
 /administrator.py
 /administrator.rb
 /admnistrator.php3
+/backend/
 /cgi-bin/sqwebmail?noframes=1
 /default.asp
 /exchange/logon.asp
 /gs/admin
 /index.php?u=
+/invocactf.php
+/login/
 /login.asp
 /login.aspx
 /login.cfm
@@ -45,4 +49,7 @@
 /typo3/in
 /utilities/TreeView.asp
 /webeditor.php
-/invocactf.php
+/wp-admin/
+/wp-login.php
+/wp-signup.php
+/wp-register.php


### PR DESCRIPTION
Added common Wordpress and Shopware CMS's login forms + Djangon and Flask admin pages cover-up

References:
https://docs.djangoproject.com/en/2.1/ref/contrib/admin/
https://premium.wpmudev.org/blog/find-wordpress-login/
https://github.com/toxydose/SecLists/blob/master/Discovery/Web-Content/CMS/wordpress.fuzz.txt
https://github.com/toxydose/SecLists/blob/master/Discovery/Web-Content/CMS/shopware.txt
https://docs.djangoproject.com/en/2.1/ref/contrib/admin/
https://www.youtube.com/watch?v=NYWEf9bZhHQ