### PR TITLE
Correct 1 typo in typo3 login ;-)

### DIFF
--- a/Discovery/Web-Content/Logins.fuzz.txt
+++ b/Discovery/Web-Content/Logins.fuzz.txt
@@ -42,7 +42,7 @@
 /logon.pl
 /logon.py
 /logon.rb
-/typo3/in
+/typo3/
 /utilities/TreeView.asp
 /webeditor.php
 /invocactf.php


### PR DESCRIPTION
/typo3/in is not _the_ login, it maybe is /a/ login. The default is just ``/typo3/``
