### PR TITLE
WP REST API v2 endpoints

### DIFF
--- a/Discovery/Web-Content/CMS/wordpress.fuzz.txt
+++ b/Discovery/Web-Content/CMS/wordpress.fuzz.txt
@@ -858,6 +858,9 @@ wp-includes/widgets.php
 wp-includes/wlwmanifest.xml
 wp-includes/wp-db.php
 wp-includes/wp-diff.php
+wp-json/
+wp-json/wp/v2/posts
+wp-json/wp/v2/users
 wp-links-opml.php
 wp-load.php
 wp-login.php

--- a/Discovery/Web-Content/quickhits.txt
+++ b/Discovery/Web-Content/quickhits.txt
@@ -2330,6 +2330,7 @@
 /wp-content/plugins/disqus-comment-system/disqus.php
 /wp-content/plugins/google-sitemap-generator/sitemap-core.php
 /wp-content/uploads/
+/wp-json/wp/v2/users
 /wp-register.php
 /wp.php
 /wp.rar/


### PR DESCRIPTION
Updated wordpress.fuzz.txt and quickhits.txt with some WP REST API v2 endpoints.

Reference: http://v2.wp-api.org/