### PR TITLE
Add sonar-project.properties and default HashiChorp Vault url to quickhits.txt

### DIFF
--- a/Discovery/Web-Content/quickhits.txt
+++ b/Discovery/Web-Content/quickhits.txt
@@ -2016,6 +2016,7 @@
 /soap/
 /soapdocs/webapps/soap/WEB-INF/config/soapConfig.xml
 /soapserver/
+/sonar-project.properties
 /source.php
 /spaw/dialogs/dialog.php
 /spaw2/dialogs/dialog.php

--- a/Discovery/Web-Content/quickhits.txt
+++ b/Discovery/Web-Content/quickhits.txt
@@ -2182,6 +2182,7 @@
 /uber/phpMemcachedAdmin/
 /uber/phpMyAdmin/
 /uber/phpMyAdminBackup/
+/ui/vault/
 /unattend.txt
 /up.php
 /UPDATE.txt


### PR DESCRIPTION
- sonar-project.properties is used by [SonarQube](https://docs.sonarqube.org/display/SCAN/Analyzing+with+SonarQube+Scanner)