### PR TITLE
.well-known dir

### DIFF
--- a/Discovery/Web-Content/common.txt
+++ b/Discovery/Web-Content/common.txt
@@ -24,6 +24,9 @@
 .svn/entries
 .swf
 .web
+.well-known/apple-app-site-association
+.well-known/assetlinks.json
+.well-known/core
 0
 00
 01
@@ -585,6 +588,7 @@ appeals
 append
 appl
 apple
+apple-app-site-association
 applet
 applets
 appliance
@@ -3455,7 +3459,6 @@ robot
 robotics
 robots
 robots.txt
-.well-known/apple-app-site-association
 role
 roles
 roller


### PR DESCRIPTION
* Add 1x apple-app-site-association, as it can appear also in docroot: https://developer.apple.com/library/archive/documentation/General/Conceptual/AppSearch/UniversalLinks.html

* Add .well-known/assetlinks.json

* Add .well-known/core (https://tools.ietf.org/html/rfc7252)

* put .well-known in alphabetical order

There might be more URI registered @ IANA (process see https://tools.ietf.org/html/rfc5785#5.1).