### PR TITLE
Add innerHTML as dangerous input in Angular 2+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .*.icloud
 .gitkeep
+.idea

--- a/Pattern-Matching/dangerous-functions-angular.txt
+++ b/Pattern-Matching/dangerous-functions-angular.txt
@@ -6,7 +6,7 @@ bypassSecurityTrustUrl
 bypassSecurityTrustResourceUrl
 
 # Angular inputs
-[innerHTML] //Insert given HTML without escaping dangerous characters
+[innerHTML] #Insert given HTML without escaping dangerous characters
 
 # angular.js (aka Angular 1)
 trustAsHtml

--- a/Pattern-Matching/dangerous-functions-angular.txt
+++ b/Pattern-Matching/dangerous-functions-angular.txt
@@ -1,8 +1,14 @@
+# Angular pipes
 bypassSecurityTrustHtml
 bypassSecurityTrustScript
 bypassSecurityTrustStyle
 bypassSecurityTrustUrl
 bypassSecurityTrustResourceUrl
+
+# Angular inputs
+[innerHTML] //Insert given HTML without escaping dangerous characters
+
+# angular.js (aka Angular 1)
 trustAsHtml
 $eval
 $evalAsync


### PR DESCRIPTION
[innerHTML] input is dangerous because it will inject given input without escaping special characters/strings