### PR TITLE
CIRT Credentials: refreshed and fixed couple issues

### DIFF
--- a/Passwords/cirt-default-passwords.txt
+++ b/Passwords/cirt-default-passwords.txt
@@ -74,7 +74,7 @@ AMIAMI
 AMIDECOD
 AMIPSWD
 AMISETUP
-AMI\_SW
+AMI_SW
 AMI~
 ANYCOM
 AP
@@ -90,8 +90,8 @@ ARCHIVIST
 AUDIOUSER
 AWARD SW
 AWARD?SW
-AWARD\_PW
-AWARD\_SW
+AWARD_PW
+AWARD_SW
 Admin
 Admin1
 Administrative
@@ -108,7 +108,7 @@ BIGO
 BIOS
 BIOSPASS
 BRIDGE
-BRIO\_ADMIN
+BRIO_ADMIN
 Babylon
 BackupU$r
 Barricade
@@ -121,7 +121,7 @@ CDEMOCOR
 CDEMORID
 CDEMOUCB
 CENTRA
-CHEY\_ARCHSVR
+CHEY_ARCHSVR
 CIDS
 CIS
 CISINFO
@@ -139,7 +139,7 @@ CONV
 CSMIG
 CTXDEMO
 CTXSYS
-CTX\_123
+CTX_123
 Cisco
 Cisco router
 Col2ogro2
@@ -159,17 +159,17 @@ DEMO
 DEMO8
 DEMO9
 DES
-DEV2000\_DEMOS
+DEV2000_DEMOS
 DIGITAL
 DIP
 DISC
-DISCOVERER\_ADMIN
+DISCOVERER_ADMIN
 DSGATEWAY
 DSL
 DSSYS
 DV5800
-D\_SYSPW
-D\_SYSTPW
+D_SYSPW
+D_SYSTPW
 Daewuu
 Daytec
 Dell
@@ -229,7 +229,7 @@ INSTANCE
 INTX3
 INVALID
 ISPMODE
-IS\_$hostname
+IS_$hostname
 ITF3000
 ImageFolio
 JDE
@@ -243,7 +243,7 @@ LBACSYS
 LINK
 LOTUS
 LR-ISDN
-LdapPassword\_1
+LdapPassword_1
 Liebert
 MAIL
 MAILER
@@ -271,7 +271,7 @@ MSHOME
 MServer
 MTRPW
 MTSSYS
-MTS\_PASSWORD
+MTS_PASSWORD
 MUMBLEFRATZ
 MXAGENT
 MagiMFP
@@ -300,7 +300,7 @@ NetICs
 NetSeq
 NetServer
 NetVCR
-OAS\_PUBLIC
+OAS_PUBLIC
 OCITEST
 ODM
 ODS
@@ -308,7 +308,7 @@ ODSCOMMON
 OE
 OEMADM
 OEMREP
-OEM\_TEMP
+OEM_TEMP
 OLAPDBA
 OO
 OP.OPERATOR
@@ -326,7 +326,7 @@ ORDSYS
 OSP22
 OUTLN
 OWA
-OWA\_PUBLIC
+OWA_PUBLIC
 OWNER
 Oper
 Operator
@@ -346,11 +346,11 @@ PO
 PO7
 PO8
 PORTAL30
-PORTAL30\_DEMO
-PORTAL30\_PUBLIC
-PORTAL30\_SSO
-PORTAL30\_SSO\_PS
-PORTAL30\_SSO\_PUBLIC
+PORTAL30_DEMO
+PORTAL30_PUBLIC
+PORTAL30_SSO
+PORTAL30_SSO_PS
+PORTAL30_SSO_PUBLIC
 PORTAL31
 POST
 POSTMASTER
@@ -374,20 +374,20 @@ QDI
 QNX
 QS
 QSRV
-QS\_ADM
-QS\_CB
-QS\_CBADM
-QS\_CS
-QS\_ES
-QS\_OS
-QS\_WS
+QS_ADM
+QS_CB
+QS_CBADM
+QS_CS
+QS_ES
+QS_OS
+QS_WS
 RAV
 RE
 REGO
 REMOTE
 REPADMIN
 REPORT
-REP\_OWNER
+REP_OWNER
 RJE
 RM
 RMAIL
@@ -401,7 +401,7 @@ SABRE
 SAMPLE
 SAP
 SAPR3
-SDOS\_ICSAP
+SDOS_ICSAP
 SECDEMO
 SECONDARY
 SECRET123
@@ -413,22 +413,22 @@ SERVICECONSUMER1
 SH
 SHELVES
 SITEMINDER
-SKY\_FOX
+SKY_FOX
 SLIDEPW
 SNOWMAN
 SQL
 STARTER
 STEEL
-STRAT\_PASSWD
+STRAT_PASSWD
 STUDENT
 SUPERSECRET
 SUPERVISOR
 SUPPORT
-SWITCHES\_SW
+SWITCHES_SW
 SWORDFISH
 SWPRO
 SWUSER
-SW\_AWARD
+SW_AWARD
 SYMPA
 SYS
 SYS1
@@ -438,7 +438,7 @@ SYSLIB
 SYSMAINT
 SYSTEM
 SYSTEST
-SYSTEST\_CLIG
+SYSTEST_CLIG
 SZYX
 Service
 SnuFG5
@@ -449,7 +449,7 @@ Sysop
 TAHITI
 TANDBERG
 TCH
-TDOS\_ICSAP
+TDOS_ICSAP
 TELEDEMO
 TELESUP
 TENmanUFactOryPOWER
@@ -483,7 +483,7 @@ USER7
 USER8
 USER9
 USERP
-USER\_TEMPLATE
+USER_TEMPLATE
 UTLESTAT
 Unidesk1
 User
@@ -491,7 +491,7 @@ VAX
 VCSRV
 VESOFT
 VIDEO USER
-VIF\_DEV\_PWD
+VIF_DEV_PWD
 VIRUSER
 VMS
 VRR1
@@ -502,10 +502,10 @@ WEBCAL01
 WEBDB
 WEBREAD
 WELCOME
-WINDOWS\_PASSTHRU
+WINDOWS_PASSTHRU
 WINSABRE
 WKSYS
-WLAN\_AP
+WLAN_AP
 WOOD
 WORD
 WWW
@@ -517,8 +517,8 @@ XPRT
 YES
 ZAAADA
 Zenith
-[^\_^]
-\_Cisco
+[^_^]
+_Cisco
 a
 aLLy
 aPAf
@@ -561,8 +561,8 @@ attack
 author
 autocad
 award.sw
-award\_?
-award\_ps
+award_?
+award_ps
 awkward
 ax400
 axis2
@@ -578,6 +578,7 @@ bciimpw
 bcimpw
 bcmspw
 bcnaspw
+bcpb(serial number of the firewall)
 bell9
 bewan
 bin
@@ -602,8 +603,9 @@ cascade
 cc
 ccrusr
 central
+cepasswd
 cgadmin
-change\_on\_install
+change_on_install
 changeit
 changeme
 changeonfirstlogin
@@ -648,7 +650,7 @@ distrib0
 disttech
 djonet
 dmr99
-dn\_04rjc
+dn_04rjc
 dni
 dnnadmin
 dnnhost
@@ -691,6 +693,7 @@ guest1
 guestgue
 h6BB
 halt
+hds
 hello
 hewlpack
 highspeed
@@ -802,6 +805,7 @@ netman
 netopia
 netscreen
 news
+niagara
 nicecti
 nician
 nimda
@@ -826,12 +830,14 @@ par0t
 pass
 passw0rd
 password
+pbcpbn(add-serial-number)
 peribit
 phplist
 phpreactor
 piranha
 pixmet2003
 pnadmin
+pointofsale
 poll
 postmast
 powerdown
@@ -920,6 +926,7 @@ ssladmin
 ssp
 sspassword
 star
+storage
 storageserver
 store
 super
@@ -945,7 +952,7 @@ syslib
 sysopr
 syspw
 system
-system\_admin
+system_admin
 t00lk1t
 t0ch20x
 t0ch88

--- a/Usernames/cirt-default-usernames.txt
+++ b/Usernames/cirt-default-usernames.txt
@@ -1,8 +1,3 @@
- EAdmin
- UAMIS\_
- UNITY\_
- UOMNI\_
- UVPIM\_
 !root
 $ALOC$
 $SRV
@@ -64,8 +59,8 @@ BATCH1
 BATCH2
 BC4J
 BLAKE
-BRIO\_ADMIN
-Best1\_User
+BRIO_ADMIN
+Best1_User
 Bill
 Bobo
 CATALOG
@@ -75,7 +70,7 @@ CDEMOCOR
 CDEMORID
 CDEMOUCB
 CENTRA
-CHEY\_ARCHSVR
+CHEY_ARCHSVR
 CICSUSER
 CIDS
 CIS
@@ -118,11 +113,11 @@ DEMO8
 DEMO9
 DES
 DESQUETOP
-DEV2000\_DEMOS
+DEV2000_DEMOS
 DIP
 DIRECT
 DIRMAINT
-DISCOVERER\_ADMIN
+DISCOVERER_ADMIN
 DISKCNT
 DS
 DSA
@@ -134,6 +129,7 @@ Denny
 Developer
 Draytek
 EARLYWATCH
+EAdmin<systemid>
 EJSADMIN
 EMP
 EREP
@@ -184,7 +180,7 @@ INGRES
 IPC
 IPFSERV
 ISPVM
-IS\_$hostname
+IS_$hostname
 IVPM1
 IVPM2
 JDE
@@ -198,7 +194,7 @@ L2LDEMO
 LASER
 LASERWRITER
 LBACSYS
-LDAP\_Anonymous
+LDAP_Anonymous
 LIBRARIAN
 LIBRARY
 LINK
@@ -216,8 +212,8 @@ MBMANAGER
 MBWATCH
 MCUser
 MDDEMO
-MDDEMO\_CLERK
-MDDEMO\_MGR
+MDDEMO_CLERK
+MDDEMO_MGR
 MDSYS
 MDaemon
 MFG
@@ -233,12 +229,11 @@ MOESERV
 MOREAU
 MSHOME
 MTSSYS
-MTS\_USER
+MTS_USER
 MXAGENT
 Manager
 Minnie
 Moe
-N/A
 NAMES
 NETCON
 NETMGR
@@ -253,10 +248,10 @@ NEWS
 NSA
 NetLinx
 Nice-admin
-OAS\_PUBLIC
+OAS_PUBLIC
 OCITEST
 ODM
-ODM\_MTR
+ODM_MTR
 ODS
 ODSCOMMON
 OE
@@ -266,7 +261,7 @@ OLAPDBA
 OLAPSVR
 OLAPSYS
 OLTSEP
-OMWB\_EMULATION
+OMWB_EMULATION
 OO
 OP1
 OPENSPIRIT
@@ -284,7 +279,7 @@ OSE$HTTP$ADMIN
 OSP22
 OUTLN
 OWA
-OWA\_PUBLIC
+OWA_PUBLIC
 OWNER
 Oper
 Operator
@@ -308,11 +303,11 @@ PO
 PO7
 PO8
 PORTAL30
-PORTAL30\_DEMO
-PORTAL30\_PUBLIC
-PORTAL30\_SSO
-PORTAL30\_SSO\_PS
-PORTAL30\_SSO\_PUBLIC
+PORTAL30_DEMO
+PORTAL30_PUBLIC
+PORTAL30_SSO
+PORTAL30_SSO_PS
+PORTAL30_SSO_PUBLIC
 POST
 POSTMASTER
 POWERCARTUSER
@@ -334,21 +329,21 @@ Polycom
 QDBA
 QS
 QSRV
-QS\_ADM
-QS\_CB
-QS\_CBADM
-QS\_CS
-QS\_ES
-QS\_OS
-QS\_WS
+QS_ADM
+QS_CB
+QS_CBADM
+QS_CS
+QS_ES
+QS_OS
+QS_WS
 RAID
 RDM470
 RE
 REPADMIN
 REPORT
-REPORTS\_USER
-REP\_MANAGER
-REP\_OWNER
+REPORTS_USER
+REP_MANAGER
+REP_OWNER
 RJE
 RMAIL
 RMAN
@@ -369,7 +364,7 @@ SAP*
 SAPCPIC
 SAPR3
 SAVSYS
-SDOS\_ICSAP
+SDOS_ICSAP
 SECDEMO
 SENTINEL
 SERVICECONSUMER1
@@ -385,7 +380,7 @@ SPOOLMAN
 SQLDBA
 SQLUSER
 STARTER
-STRAT\_USER
+STRAT_USER
 STUDENT
 SUPERVISOR
 SWPRO
@@ -403,14 +398,14 @@ SYSMAINT
 SYSMAN
 SYSTEM
 SYSTEST
-SYSTEST\_CLIG
+SYSTEST_CLIG
 SYSWRM
 Service
 SuperUser
 Sysop
 TAHITI
 TDISK
-TDOS\_ICSAP
+TDOS_ICSAP
 TELEDEMO
 TEMP
 TEST
@@ -427,8 +422,11 @@ TURBINE
 Tasman
 Telecom
 Test Everything
+UAMIS_<servername>
 UETP
 ULTIMATE
+UNITY_<servername>
+UOMNI_<servername>
 USER
 USER0
 USER1
@@ -442,15 +440,16 @@ USER8
 USER9
 USERID
 USERP
-USER\_TEMPLATE
+USER_TEMPLATE
 UTLBSTATU
+UVPIM_<servername>
 User
 Username
 VASTEST
 VAX
 VCSRV
 VIDEOUSER
-VIF\_DEVELOPER
+VIF_DEVELOPER
 VIRUSER
 VM3812
 VMARCH
@@ -476,7 +475,7 @@ WEBADM
 WEBCAL01
 WEBDB
 WEBREAD
-WINDOWS\_PASSTHRU
+WINDOWS_PASSTHRU
 WINSABRE
 WKSYS
 WP
@@ -486,9 +485,9 @@ WebAdmin
 WinCCAdmin
 WinCCConnect
 XPRT
-XXSESS\_MGRYY
+XXSESS_MGRYY
 Yak
-\_\_super
+__super
 accounting
 adfexc
 adm
@@ -527,6 +526,7 @@ bubba
 builtin
 cablecom
 ccrusr
+ceconsl
 cgadmin
 checkfs
 checkfsys
@@ -540,8 +540,8 @@ cn=orcladmin
 conferencing
 core
 craft
-crowd­-openid-­server
-ctb\_admin
+crowd-openid-server
+ctb_admin
 cusadmin
 cust
 dadmin
@@ -574,13 +574,13 @@ echo
 enable
 eng
 enquiry
-epiq\_api
+epiq_api
 factory
 fal
 fam
 fastwire
 fax
-fg\_sysadmin
+fg_sysadmin
 field
 firstsite
 ftp
@@ -667,11 +667,12 @@ news
 nm2user
 nms
 nobody
+none
 nsroot
 ntpupdate
 nuucp
 ods
-onlime\_r
+onlime_r
 op
 openfiler
 operator
@@ -687,7 +688,7 @@ powerdown
 prime
 primenet
 primeos
-primos\_cs
+primos_cs
 private ReadWrite access
 prtgadmin
 public ReadOnly access
@@ -764,7 +765,7 @@ sysadmin
 sysbin
 sysopr
 system
-system\_admin
+system_admin
 t3admin
 tasman
 teacher
@@ -780,6 +781,7 @@ topicalt
 topicnorm
 topicres
 tour
+tridium
 trmcnfg
 trouble
 tutor
@@ -789,16 +791,16 @@ umountsys
 unix
 user
 userNotUsed
-user\_analyst
-user\_approver
-user\_author
-user\_checker
-user\_designer
-user\_editor
-user\_expert
-user\_marketer
-user\_pricer
-user\_publisher
+user_analyst
+user_approver
+user_author
+user_checker
+user_designer
+user_editor
+user_expert
+user_marketer
+user_pricer
+user_publisher
 username
 uucp
 uucpadm
@@ -811,7 +813,7 @@ voadmin
 volition
 vpasp
 web
-web\_api
+web_api
 webadmin
 weblogic
 webmaster
@@ -822,4 +824,4 @@ wlse
 wradmin
 write
 www
-xmi\_demo
+xmi_demo


### PR DESCRIPTION
Recently tried using the cirt data set, but found it had a few issues.

After looking at the discussion in #201, (the issue of `\_` being present still remained) and noticing a  unicode and whitespace issue I rebuilt the both the username list and password list to be sure they were correct. As a slight benefit couple new entries have been added.