### PR TITLE
add a common windows lfi path

### DIFF
--- a/Fuzzing/LFI/LFI-Jhaddix.txt
+++ b/Fuzzing/LFI/LFI-Jhaddix.txt
@@ -736,6 +736,8 @@ users/.htpasswd
 /web/conf/php.ini
 /WINDOWS\php.ini
 ../../windows/win.ini
+../../../../../../../../windows/win.ini
+..\..\..\..\..\..\..\..\windows\win.ini
 /WINNT\php.ini
 /..\..\..\..\..\..\winnt\win.ini
 /www/logs/proftpd.system.log


### PR DESCRIPTION
These paths are already present in 
`/Fuzzing/Windows-Attacks.fuzzdb.txt`,
however I think they should also be in here.