### PR TITLE
Add .well-known entries

### DIFF
--- a/Discovery/Web-Content/common.txt
+++ b/Discovery/Web-Content/common.txt
@@ -39,6 +39,7 @@
 .well-known/csvm
 .well-known/dnt
 .well-known/dnt-policy.txt
+.well-known/dots
 .well-known/ecips
 .well-known/enterprise-transport-security
 .well-known/est
@@ -52,6 +53,7 @@
 .well-known/keybase.txt
 .well-known/looking-glass
 .well-known/matrix
+.well-known/mercure
 .well-known/mta-sts.txt
 .well-known/mud
 .well-known/nfv-oauth-server-configuration
@@ -63,6 +65,7 @@
 .well-known/openpgpkey
 .well-known/pki-validation
 .well-known/posh
+.well-known/pvd
 .well-known/reload-config
 .well-known/repute-template
 .well-known/resourcesync


### PR DESCRIPTION
"dots" and "pvd" are recent (2020) entries from [IANA](https://www.iana.org/assignments/well-known-uris/well-known-uris.xhtml)
"mercure" was found in https://gist.github.com/quickbreach/3bddfdf193b3d988b0e07d07dbac0da0 and appears in the [unofficial spec for Mercure protocol](https://mercure.rocks/spec#discovery)