### PR TITLE
Add characters that can break a MongoDB query when JS expression is used

### DIFF
--- a/Fuzzing/Databases/NoSQL.txt
+++ b/Fuzzing/Databases/NoSQL.txt
@@ -18,3 +18,12 @@ db.injection.insert({success:1});return 1;db.stores.mapReduce(function() { { emi
 ';sleep(5000);
 ';it=new%20Date();do{pt=new%20Date();}while(pt-it<5000);
 {$nin: [""]}}
+' 
+"
+\
+/
+//
+; 
+{
+} 
+:


### PR DESCRIPTION
Hi,

During my work on the box MANGO from HTB and after reading some documentation about MongoDB, I have learned that there are some characters that can break a query when a JS expression is used like the following:

[source](https://github.com/Charlie-belmer/vulnerable-node-app/blob/master/app/routes/user.route.js#L8)

```javascript
let username = req.query.username;
query = { $where: `this.username == '${username}'` }
User.find(query, function (err, users) {/*...*/}
```
I have added a list of characters to the NoSQL dict in order to detect usage of a JS expression during a fuzzing operation and then identify a location in which a MongoDB query is used and in which we can influence the processing:

![image](https://user-images.githubusercontent.com/1573775/87856734-524b6d00-c921-11ea-8025-abf072917616.png)

I don't know if you can find this add useful for this dict so at least I propose a PR and let you decide 😃 

Thank you very much in advance.

