### PR TITLE
Add NDES and SCEP URLs

### DIFF
--- a/Discovery/Web-Content/IIS.fuzz.txt
+++ b/Discovery/Web-Content/IIS.fuzz.txt
@@ -28,6 +28,8 @@
 /certcontrol/
 /certenroll/
 /certsrv/
+/certsrv/mscep_admin
+/certsrv/mscep/mscep.dll
 /cfide/..%255c..%255c..%255c..%255cwinnt/system32/cmd.exe?/c+dir
 /CFIDE/Administrator/startstop.html
 /cgi/


### PR DESCRIPTION
Microsoft Network Device Enrollment Service (NDES) is used to enroll
devices such as Cisco routers and iPhones with a device certificate
issued by Active Directory Certificate Services (ADCS) Certification
Authority (CA) via the Simple Certificate Enrollment Protocol (SCEP).

Add the following URLs:

* /certsrv/mscep_admin - admin page of Network Device Enrollment Service
  (NDES)
* /certsrv/mscep/mscep.dll - Simple Certificate Enrollment Protocol
  (SCEP) server endpoint