### PR TITLE
Add path to a common ManageEngine endpoint

### DIFF
--- a/Discovery/Web-Content/common.txt
+++ b/Discovery/Web-Content/common.txt
@@ -3667,6 +3667,7 @@ servicios
 servlet
 servlets
 servlets-examples
+servlet/GetProductVersion
 sess
 session
 sessionid


### PR DESCRIPTION
Hello,

This PR add a path to a endpoint often exposed to anonymous users by [ManageEngine products](https://www.manageengine.com).

Its allow to identify the product name/version, OS and other internals information:

![note](https://user-images.githubusercontent.com/1573775/94894577-f016f880-0489-11eb-8992-00b77d129bf9.png)

Thank you very much in advance 😃 