### PR TITLE
Adding nextcloud & owncloud to common.txt

### DIFF
--- a/Discovery/Web-Content/common.txt
+++ b/Discovery/Web-Content/common.txt
@@ -2789,6 +2789,7 @@ newstarter
 newthread
 newticket
 next
+nextcloud
 nfs
 nice
 nieuws
@@ -2922,6 +2923,7 @@ oversikt
 overview
 owa
 owl
+owncloud
 owners
 ows
 ows-bin


### PR DESCRIPTION
Hey 🙂 

Nextcloud & ownCloud are two famous software for creating and using file hosting service.


PS: this adding might also be done on bigger discovery list because none of big list contains them