### PR TITLE
Add CMS login

### DIFF
--- a/Discovery/Web-Content/Logins.fuzz.txt
+++ b/Discovery/Web-Content/Logins.fuzz.txt
@@ -72,6 +72,7 @@
 /phpmyadmin
 /phpmyadmin/
 /phpmyadmin/index.php
+/processwire/
 /signin
 /signin/
 /signin.php?ret=


### PR DESCRIPTION
Processwire is a CMS which I recently encountered during a pentest. /processwire is the login (compare /typo3 or /wp-login.php)