### PR TITLE
Adding .git to big.txt

### DIFF
--- a/Discovery/Web-Content/big.txt
+++ b/Discovery/Web-Content/big.txt
@@ -11,6 +11,7 @@
 .cvs
 .cvsignore
 .forward
+.git
 .history
 .htaccess
 .htpasswd


### PR DESCRIPTION
I think this wordlist is well used and I missed .git several times on HackTheBox and recruitement challenges because .git isn't in this wordlist, and I'm not the only one so I think we should add it. 😄 