### PR TITLE
Add ".well-known/jwks.json" path to common.txt file.

### DIFF
--- a/Discovery/Web-Content/common.txt
+++ b/Discovery/Web-Content/common.txt
@@ -50,6 +50,7 @@
 .well-known/http-opportunistic
 .well-known/idp-proxy
 .well-known/jmap
+.well-known/jwks.json
 .well-known/keybase.txt
 .well-known/looking-glass
 .well-known/matrix


### PR DESCRIPTION
Hi,

This PR add the path to the JSON Web Key Sets file. 

It refer to the issue #548 .

This file is documented in the following locations:
- [Auth0](https://auth0.com/docs/tokens/json-web-tokens/json-web-key-sets)
- [AWS](https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-using-tokens-verifying-a-jwt.html#amazon-cognito-user-pools-using-tokens-step-2)
- [Akamai](https://blogs.akamai.com/2019/10/verify-jwt-with-json-web-key-set-jwks-in-api-gateway.html)

Thank you very much in advance 😃 