### PR TITLE
Added Zyxel default username and password based on CVE-2020-29583

### DIFF
--- a/Passwords/cirt-default-passwords.txt
+++ b/Passwords/cirt-default-passwords.txt
@@ -848,6 +848,7 @@ primos
 private
 prost
 protection
+PrOw!aN_fXp
 prtgadmin
 public
 publish

--- a/Usernames/cirt-default-usernames.txt
+++ b/Usernames/cirt-default-usernames.txt
@@ -825,3 +825,5 @@ wradmin
 write
 www
 xmi_demo
+zyfwp
+zyad5001


### PR DESCRIPTION
Hi 

I added the newly discovered  hardcoded credentials for Zyxel devices to the cirt list. This is based on the following source:
https://www.eyecontrol.nl/blog/undocumented-user-account-in-zyxel-products.html

Reg.
m4p0