### PR TITLE
Added Zyxel default username and password (CVE-2020-29583 / CVE-2016-10401)

### DIFF
--- a/Passwords/cirt-default-passwords.txt
+++ b/Passwords/cirt-default-passwords.txt
@@ -361,6 +361,7 @@ PRINTER
 PRIV
 PRODCICS
 PROG
+PrOw!aN_fXp
 PUBSUB
 PUBSUB1
 Password
@@ -1037,3 +1038,4 @@ zebra
 zeosx
 zjaaadc
 zoomadsl
+zyad5001

--- a/Usernames/cirt-default-usernames.txt
+++ b/Usernames/cirt-default-usernames.txt
@@ -825,3 +825,4 @@ wradmin
 write
 www
 xmi_demo
+zyfwp


### PR DESCRIPTION
Hi

I added the newly discovered hardcoded credentials for Zyxel devices to the cirt list. This is based on the following source:
https://www.eyecontrol.nl/blog/undocumented-user-account-in-zyxel-products.html

Reg.
m4p0