### PR TITLE
Add default password for jailbroken iOS (iPhone, iPad, iPod Touch, AppleTV)

### DIFF
--- a/Passwords/Common-Credentials/top-20-common-SSH-passwords.txt
+++ b/Passwords/Common-Credentials/top-20-common-SSH-passwords.txt
@@ -19,3 +19,4 @@ techsupport
 letmein
 logon
 Passw@rd
+alpine


### PR DESCRIPTION
once jailbroken `alpine` is the default password for both root and mobile