### PR TITLE
Add Microsoft Blazor WebAssembly identifiers

### DIFF
--- a/Discovery/Web-Content/common.txt
+++ b/Discovery/Web-Content/common.txt
@@ -369,6 +369,10 @@ _dummy
 _files
 _flash
 _fpclass
+_framework/blazor.boot.json
+_framework/blazor.webassembly.js
+_framework/wasm/dotnet.wasm
+_framework/_bin/WebAssembly.Bindings.dll
 _images
 _img
 _inc


### PR DESCRIPTION
Hi,

This PR add some files that can be used to identify the presence of a [Microsoft  Blazor WebAssembly](https://en.wikipedia.org/wiki/Blazor) application.

The information about these files was taken from a internal company lab that I performed recently as well as this [sample application](https://github.com/SteveSandersonMS/CarChecker).

Thank you very much in advance 😃 