### PR TITLE
Add security.txt at the root

### DIFF
--- a/Discovery/Web-Content/common.txt
+++ b/Discovery/Web-Content/common.txt
@@ -3650,6 +3650,7 @@ secureform
 secureprocess
 securimage
 security
+security.txt
 seed
 select
 selectaddress


### PR DESCRIPTION
Hi,

This PR add the `security.txt` file at the root of the website because according to this [doc](https://securitytxt.org/), it can be located on the following path:
* `/.well-known/security.txt`
* `/security.txt` 

![image](https://user-images.githubusercontent.com/1573775/114821289-a1470580-9dc0-11eb-82f6-2f9033f7a375.png)

I have checked and the entry `/security.txt` was not already present:

![image](https://user-images.githubusercontent.com/1573775/114821341-b7ed5c80-9dc0-11eb-9a55-eb4c098ece08.png)

Thanks a lot in advance 😃 