### PR TITLE
Add oauth and openid missing endpoints

### DIFF
--- a/Discovery/Web-Content/common.txt
+++ b/Discovery/Web-Content/common.txt
@@ -2848,6 +2848,8 @@ nz
 o
 oa_servlets
 oauth
+oauth/authorize
+oauth/token
 obdc
 obj
 object

--- a/Discovery/Web-Content/common.txt
+++ b/Discovery/Web-Content/common.txt
@@ -76,6 +76,7 @@
 .well-known/nodeinfo
 .well-known/oauth-authorization-server
 .well-known/openid-configuration
+.well-known/openid-federation
 .well-known/openorg
 .well-known/openpgpkey
 .well-known/pki-validation
@@ -1758,6 +1759,7 @@ fdcp
 feature
 featured
 features
+federation/clients
 fedora
 feed
 feedback
@@ -2351,6 +2353,7 @@ jump
 juniper
 junk
 jvm
+jwks.json
 k
 katalog
 kb
@@ -2981,6 +2984,7 @@ panelc
 paper
 papers
 parse
+par
 part
 partenaires
 partner
@@ -4153,6 +4157,9 @@ today
 todel
 todo
 toggle
+token
+token/introspect
+token/revoke
 tomcat
 tomcat-docs
 tool

--- a/Discovery/Web-Content/common.txt
+++ b/Discovery/Web-Content/common.txt
@@ -2853,6 +2853,7 @@ oa_servlets
 oauth
 oauth/authorize
 oauth/token
+oauth/token/info
 obdc
 obj
 object


### PR DESCRIPTION
Hi,

This PR add the following elements:
* oauth endpoints based on [this article](https://auth0.com/docs/protocols/protocol-oauth2#endpoints) and [this article](https://docs.gitlab.com/ee/api/oauth2.html#retrieving-the-token-information).
* openid endpoints and meatdata files based on [this article](https://connect2id.com/products/server/docs/api).

I was thinking to add a dedicated file but as the **common.txt** file already contains a bunch of metadata files, I have proposed to add the missing elements into it.

Feel free to reject the PR if you prefer that I create a dedicated dict file for oauth-openid elements.

Thanks in advance 😃 