### PR TITLE
Add Shibboleth.sso Metadata endpoint

### DIFF
--- a/Discovery/Web-Content/common.txt
+++ b/Discovery/Web-Content/common.txt
@@ -319,6 +319,7 @@ ServerAdministrator
 Services
 Servlet
 Servlets
+Shibboleth.sso/Metadata
 SiteMap
 SiteScope
 SiteServer


### PR DESCRIPTION
Hi,

This PR add the metadata endpoint for the [Shibboleth.sso](https://www.shibboleth.net/) framework:
* Information was based on this [source](https://wiki.shibboleth.net/confluence/display/CONCEPT/MetadataForSP).

![image](https://user-images.githubusercontent.com/1573775/121027537-54bbed00-c7a7-11eb-9230-54c514174e69.png)

Thank a lot in advance 😃 
