### PR TITLE
Add "UniqueId" http request header

### DIFF
--- a/Miscellaneous/web/http-request-headers/http-request-headers-fields-large.txt
+++ b/Miscellaneous/web/http-request-headers/http-request-headers-fields-large.txt
@@ -744,6 +744,7 @@ Ua-Voice
 Unauthorized
 Unencoded-Url
 Unit-Test-Mode
+UniqueId
 Unless-Modified-Since
 Unprocessable-Entity
 Unsupported-Media-Type


### PR DESCRIPTION
Hi,

This PR add the header **UniqueId** to the file [http-request-headers-fields-large.txt](https://github.com/danielmiessler/SecLists/blob/master/Miscellaneous/web/http-request-headers/http-request-headers-fields-large.txt), I have seen it often during web pentest.

I think that it can be interesting to target it in a fuzzing operation because it can perhaps lead to an injection point depending on how it is consumed by the web app.

Thank in advance 😃 