### PR TITLE
A very new naming scheme

### DIFF
--- a/Discovery/Web-Content/graphql.txt
+++ b/Discovery/Web-Content/graphql.txt
@@ -17,6 +17,7 @@ graphql/schema.yaml
 playground
 subscriptions
 api/graphql
+je/graphql
 graph
 v1/altair
 v1/explorer


### PR DESCRIPTION
I have noticed a new naming convention surge in companies, having Graphql API endpoint as `example.com/je/graphql`. This is something I encountered while doing BBs on HackerOne.