### PR TITLE
Add missing OAUTH2/OIDC endpoints.

### DIFF
--- a/Discovery/Web-Content/common.txt
+++ b/Discovery/Web-Content/common.txt
@@ -736,6 +736,7 @@ authentication
 author
 authoring
 authorization
+authorize
 authorized_keys
 authors
 authuser
@@ -2653,6 +2654,7 @@ metabase
 metadata
 metaframe
 metatags
+mfa/challenge
 mgr
 michael
 microsoft
@@ -2853,6 +2855,8 @@ o
 oa_servlets
 oauth
 oauth/authorize
+oauth/device/code
+oauth/revoke
 oauth/token
 oauth/token/info
 obdc
@@ -2874,6 +2878,7 @@ office
 offices
 offline
 ogl
+oidc/register
 old
 old-site
 old_site


### PR DESCRIPTION
Hi,

This PR add missing OAuth 2.0 and Open ID Connect endpoints based on [this descriptor](https://righettod.eu.auth0.com/.well-known/openid-configuration):

```json
{
  "issuer": "https://righettod.eu.auth0.com/",
  "authorization_endpoint": "https://righettod.eu.auth0.com/authorize",
  "token_endpoint": "https://righettod.eu.auth0.com/oauth/token",
  "device_authorization_endpoint": "https://righettod.eu.auth0.com/oauth/device/code",
  "userinfo_endpoint": "https://righettod.eu.auth0.com/userinfo",
  "mfa_challenge_endpoint": "https://righettod.eu.auth0.com/mfa/challenge",
  "jwks_uri": "https://righettod.eu.auth0.com/.well-known/jwks.json",
  "registration_endpoint": "https://righettod.eu.auth0.com/oidc/register",
  "revocation_endpoint": "https://righettod.eu.auth0.com/oauth/revoke"
}
``` 

Thanks in advance 😃 