### PR TITLE
Add waybackverify.txt filename to raft medium and large lists

### DIFF
--- a/Discovery/Web-Content/raft-large-files-lowercase.txt
+++ b/Discovery/Web-Content/raft-large-files-lowercase.txt
@@ -3922,6 +3922,7 @@ vieworder.cfm
 viewprofile.php
 warranty.php
 watermark.php
+waybackverify.txt
 webmaster.html
 widerrufsrecht.html
 wizard.asp

--- a/Discovery/Web-Content/raft-large-files.txt
+++ b/Discovery/Web-Content/raft-large-files.txt
@@ -36622,6 +36622,7 @@ water.php
 water.swf
 waterfront.htm
 watermark.png
+waybackverify.txt
 waytoomany.html
 wblogin.php
 wc.php

--- a/Discovery/Web-Content/raft-medium-files-lowercase.txt
+++ b/Discovery/Web-Content/raft-medium-files-lowercase.txt
@@ -16093,6 +16093,7 @@ washington.html
 watchlist.php
 water.html
 watermark.axd
+waybackverify.txt
 wbclick.htm
 we4.0
 web-development.php

--- a/Discovery/Web-Content/raft-medium-files.txt
+++ b/Discovery/Web-Content/raft-medium-files.txt
@@ -16977,6 +16977,7 @@ washington.html
 watchlist.php
 water.html
 watermark.axd
+waybackverify.txt
 wbclick.htm
 we4.0
 web-development.php


### PR DESCRIPTION
In order to send a request to the WayBack Archive, you need to prove your identity.

One of the normalized way to prove ownership is to add a waybackverify.txt file to the root of your domain containing your request regarding what you want them to do with your website archives.

I think it's worth having this one in the list as it may contain private information about the website owner.

Source/examples:
- [https://github.com/sykesgabri/TheFinalCity/blob/main/waybackverify.txt](https://github.com/sykesgabri/TheFinalCity/blob/main/waybackverify.txt)
- [https://github.com/danburd/danburd.github.io/blob/60cdebcd088eaa1363dab1cfd8a67560db38b2cc/waybackverify.txt](https://github.com/danburd/danburd.github.io/blob/60cdebcd088eaa1363dab1cfd8a67560db38b2cc/waybackverify.txt)
- [https://github.com/rawrmaan/rawrmaan.github.io/blob/b8811a8308cb51d420f23c590dce42438d24ef9c/waybackverify.txt](https://github.com/rawrmaan/rawrmaan.github.io/blob/b8811a8308cb51d420f23c590dce42438d24ef9c/waybackverify.txt)
- Google: 
![image](https://user-images.githubusercontent.com/31401273/125442242-59131bbf-6b2c-452c-95a5-defc9747c255.png)
- Screenshot of their normalized response to archive management requests by email: 
![image](https://user-images.githubusercontent.com/31401273/125442324-0e2685a1-b168-4d99-b490-0b329b934790.png)
