### PR TITLE
Added ga-google-analytics in wp-plugins.txt

### DIFF
--- a/Discovery/Web-Content/CMS/wp-plugins.fuzz.txt
+++ b/Discovery/Web-Content/CMS/wp-plugins.fuzz.txt
@@ -46,7 +46,6 @@ wp-content/plugins/7hide/
 wp-content/plugins/7uploads/
 wp-content/plugins/893-the-current-realtime-playlist/
 wp-content/plugins/9mp-url-shortener-with-hash-tag/
-wp-content/plugins/Steef/
 wp-content/plugins/a-colored-tag-cloud/
 wp-content/plugins/a-qr-code-gcapi/
 wp-content/plugins/a-qr-code/
@@ -4047,6 +4046,7 @@ wp-content/plugins/g2image/
 wp-content/plugins/g3-avatar/
 wp-content/plugins/g4b-photo-gallery/
 wp-content/plugins/g6/
+wp-content/plugins/ga-google-analytics/
 wp-content/plugins/gaboinked-chipin-sidebar-widget/
 wp-content/plugins/gadu-gadu-widget-plugin/
 wp-content/plugins/gaf-text-link/
@@ -9656,6 +9656,7 @@ wp-content/plugins/stealth-publish/
 wp-content/plugins/stealth-update/
 wp-content/plugins/steam-community-gamestats-widget/
 wp-content/plugins/steam-community-widget/
+wp-content/plugins/Steef/
 wp-content/plugins/sticky-front-page-categories-and-tags/
 wp-content/plugins/sticky-manager/
 wp-content/plugins/sticky-menu/


### PR DESCRIPTION
From: https://wordpress.org/plugins/ga-google-analytics/

---

Also, sorted the list. 

Newly added line: `wp-content/plugins/ga-google-analytics/`

```
Plugin Name: GA Google Analytics
Plugin URI: https://perishablepress.com/google-analytics-plugin/
Description: Adds your Google Analytics Tracking Code to your WordPress site.
Tags: analytics, ga, google, google analytics, tracking, statistics, stats
Author: Jeff Starr
Author URI: https://plugin-planet.com/
Donate link: https://monzillamedia.com/donate.html
Contributors: specialk
Requires at least: 4.1
Tested up to: 5.3
Stable tag: 20191109
Version: 20191109
Requires PHP: 5.6.20
Text Domain: ga-google-analytics
Domain Path: /languages
License: GPL v2 or later
```