### PR TITLE
Adding Spring Boot Gateway Actuator

### DIFF
--- a/Discovery/Web-Content/spring-boot.txt
+++ b/Discovery/Web-Content/spring-boot.txt
@@ -18,6 +18,7 @@ shutdown
 version
 auditevents
 beans
+gateway/routes
 actuator
 actuator/auditLog
 actuator/auditevents
@@ -32,6 +33,7 @@ actuator/events
 actuator/exportRegisteredServices
 actuator/features
 actuator/flyway
+actuator/gateway/routes
 actuator/health
 actuator/healthcheck
 actuator/heapdump


### PR DESCRIPTION
The gateway actuator can be used to view, add, and delete routes. The general request to `gateway` or `actuator/gateway` will return a 404. Displaying the routes should be sufficient in showing that this actuator is enabled.

Reference: https://wya.pl/2021/12/20/bring-your-own-ssrf-the-gateway-actuator/