### PR TITLE
Add Baicells default creds from CVE-2022-24693

### DIFF
--- a/Passwords/Default-Credentials/default-passwords.csv
+++ b/Passwords/Default-Credentials/default-passwords.csv
@@ -394,6 +394,8 @@ BMC Software,Best1_User,BackupU$r,http://krebsonsecurity.com/2014/01/new-clues-i
 BMC,patrol,patrol,
 BNI,USER,USER,
 BT,admin,admin,
+Baicells,admin,Baicells,CVE-2022-24693
+Baicells,anonymous,pqmz325,CVE-2022-24693
 "Barco, Inc.",<BLANK>,clickshare,https://www.barco.com/tde/(2331390682231610)/R5900004/08/Barco_InstallationManual_R5900004_08__ClickShare-CSC-1-Installation-Guide.pdf
 "Barco, Inc.",admin,admin,https://www.barco.com/tde/(2331390682231610)/R5900004/08/Barco_InstallationManual_R5900004_08__ClickShare-CSC-1-Installation-Guide.pdf
 Barracuda,admin,admin,http://www.barracudanetworks.com/ns/downloads/Quick_Start_Guides/QSG_Barracuda_SSLVPN_US.pdf


### PR DESCRIPTION
Added discovered default creds from CVE-2022-24693 that were missing in this list.

