### PR TITLE
Add OPNsense to default-passwords

### DIFF
--- a/Passwords/Default-Credentials/default-passwords.csv
+++ b/Passwords/Default-Credentials/default-passwords.csv
@@ -1720,6 +1720,7 @@ OCE,<N/A>,0 and the number of OCE printer,
 ODS,ods,ods,
 OMRON,<N/A>,<BLANK>,
 OPEN Networks,root,0P3N,
+OPNsense,root,opnsense,
 OSMC,osmc,osmc,
 OTRS Inc.,root@localhost,root,http://doc.otrs.org/2.4/en/html/c444.html
 Oki,admin,<SEE COMMENT>,Last 6 characters of the MAC address in uppercase

--- a/Passwords/Default-Credentials/default-passwords.txt
+++ b/Passwords/Default-Credentials/default-passwords.txt
@@ -1306,3 +1306,4 @@ xd
 alphaadmin
 alphacom
 1851
+opnsense


### PR DESCRIPTION
OPNsense is an open source firewall and security platform, similar to the functionality of pfSense, which is already on the list.