### PR TITLE
update site to download password lists

### DIFF
--- a/Passwords/url-to-download-passwords.md
+++ b/Passwords/url-to-download-passwords.md
@@ -1,3 +1,4 @@
 Some passwords lists are +100MB and can't be stored on the repository. The following are external links to download more:
 
 - [Weekpass](https://weakpass.com/)
+- [Breach compilation](https://web.archive.org/web/20200501154512/https://gist.github.com/scottlinux/9a3b11257ac575e4f71de811322ce6b3)

--- a/Passwords/url-to-download-passwords.md
+++ b/Passwords/url-to-download-passwords.md
@@ -1,3 +1,3 @@
-Some passwords lists are host on GitHub (+100MB). The following are external links to download more:
+Some passwords lists are +100MB and can't be stored on the repository. The following are external links to download more:
 
-- [1.4 billion password breach compilation wordlist](https://gist.github.com/scottlinux/9a3b11257ac575e4f71de811322ce6b3)
+- [Weekpass](https://weakpass.com/)


### PR DESCRIPTION
The previous Gist link was dead, adding weakpass instead