### PR TITLE
Fixes #54: Reduced repo size

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ wget -c https://github.com/danielmiessler/SecLists/archive/master.zip -O SecList
 ```
 
 **Git (Small)**
+This clones the repository _without_ the commit history. As of writing this, the commit history weights about **842 Megabytes**. This option is good if you don't plan on contributing to the project.
 
 ```
 git clone --depth 1 \


### PR DESCRIPTION
Regarding #54:
I added an explanation to the README to explain why someone would want to use the "small" command.
I also ran `git reflog expire --expire=now --all` and `git gc --prune=now --aggressive`. It only took a couple of minutes, and it reduced the size of .git from 862268KB to 818808KB. A 43.46MB difference.

This fixes #54 