### PR TITLE
Spring Boot RCE involving JMX enabled

### DIFF
--- a/Discovery/Web-Content/spring-boot.txt
+++ b/Discovery/Web-Content/spring-boot.txt
@@ -79,6 +79,7 @@ actuator/status
 actuator/threaddump
 actuator/trace
 actuator/prometheus
+actuator/env/spring.jmx.enabled
 jolokia
 list
 docs


### PR DESCRIPTION
Extracted from https://github.com/pyn3rd/Spring-Boot-Vulnerability#0x05-spring-boot-rce-involving-jmx-enabled