### PR TITLE
Update "common.txt" dict with common front end app files.

### DIFF
--- a/Discovery/Web-Content/common.txt
+++ b/Discovery/Web-Content/common.txt
@@ -1,9 +1,13 @@
 .bash_history
 .bashrc
+.browserslistrc
 .cache
 .config
 .cvs
 .cvsignore
+.env.development
+.env.production
+.eslintrc.js
 .forward
 .git
 .git-rewrite
@@ -17,6 +21,7 @@
 .gitignore
 .gitk
 .gitkeep
+.gitlab-ci.yml
 .gitmodules
 .gitreview
 .history
@@ -35,6 +40,9 @@
 .subversion
 .svn
 .svn/entries
+.svn/format
+.svn/wc.db
+.svn/wc.db-journal
 .svnignore
 .swf
 .web
@@ -394,10 +402,10 @@ _dummy
 _files
 _flash
 _fpclass
+_framework/_bin/WebAssembly.Bindings.dll
 _framework/blazor.boot.json
 _framework/blazor.webassembly.js
 _framework/wasm/dotnet.wasm
-_framework/_bin/WebAssembly.Bindings.dll
 _images
 _img
 _inc
@@ -521,7 +529,6 @@ admin
 admin-admin
 admin-console
 admin-interface
-administrator-panel
 admin.cgi
 admin.php
 admin.pl
@@ -549,6 +556,7 @@ administrat
 administratie
 administration
 administrator
+administrator-panel
 administratoraccounts
 administrators
 administrivia
@@ -781,6 +789,7 @@ b
 b1
 b2b
 b2c
+babel.config.js
 back
 back-up
 backdoor
@@ -2032,8 +2041,8 @@ gv_redeem
 gv_send
 gwt
 gz
-h2-console
 h
+h2-console
 hack
 hacker
 hacking
@@ -2324,6 +2333,7 @@ jdbc
 jdk
 jennifer
 jessica
+jest.config.js
 jexr
 jhtml
 jigsaw
@@ -2977,6 +2987,8 @@ p7pm
 pa
 pack
 package
+package.json
+package.lock
 packaged
 packages
 packaging
@@ -3001,8 +3013,8 @@ panel
 panelc
 paper
 papers
-parse
 par
+parse
 part
 partenaires
 partner
@@ -3491,8 +3503,8 @@ removals
 remove
 removed
 render
-render?url=https://www.google.com
 render/https://www.google.com
+render?url=https://www.google.com
 rendered
 reorder
 rep
@@ -3715,9 +3727,9 @@ service
 services
 servicios
 servlet
+servlet/GetProductVersion
 servlets
 servlets-examples
-servlet/GetProductVersion
 sess
 session
 sessionid
@@ -4240,6 +4252,7 @@ trends
 trial
 true
 trunk
+tsconfig.json
 tslib
 tsweb
 tt
@@ -4428,6 +4441,7 @@ vpg
 vpn
 vs
 vsadmin
+vue.config.js
 vuln
 vvc_display
 w
@@ -4655,6 +4669,7 @@ xyz
 xyzzy
 y
 yahoo
+yarn.lock
 year
 yearly
 yesterday


### PR DESCRIPTION
Hi,

This PR performed the following content on the file [common.txt](https://github.com/danielmiessler/SecLists/tree/master/Discovery/Web-Content/common.txt) :

1) Add the following entries, often seen in front end app using framework like [Angular](https://angular.io/), [ReactJS](https://reactjs.org/) or [Vue.js](https://vuejs.org/):

```text
.browserslistrc
.env.development
.env.production
.eslintrc.js
.gitignore
.gitlab-ci.yml
babel.config.js
jest.config.js
package.json
tsconfig.json
vue.config.js
yarn.lock
package.lock
.svn/entries
.svn/format
.svn/wc.db
.svn/wc.db-journal
```

2) Perform a `sort -u` against the entire updated content to remove duplicate and sort entries alphabetically.

Thanks in advance 😃 
