### PR TITLE
Revert "added new backupfiles in wordpress fuzz list"

### DIFF
--- a/Discovery/Web-Content/CMS/wordpress.fuzz.txt
+++ b/Discovery/Web-Content/CMS/wordpress.fuzz.txt
@@ -1569,15 +1569,3 @@ wp-settings.php
 wp-signup.php
 wp-trackback.php
 xmlrpc.php
-.vscode
-cgi-bin
-wp-snapshots
-.htaccess
-.viminfo
-config.codekit
-dup-installer-bootlog
-i.php
-installer-backup.php
-installer.php
-license.tet
-wordfence-waf.php


### PR DESCRIPTION
Reverts danielmiessler/SecLists#813

There was a comment pending in that pull request that the maintainer didn't answer. I think these changes should be unmade

> The following filenames are already in this repository but in other wordlists, and aren't related to wordpress:
> - .viminfo
> - .vscode
> - cgi-bin
> - .htaccess
> - config.codekit
> 
> <br>
> 
> I think it makes sense to add the rest:
> - dup-installer-bootlog
> - wp-snapshots
> - installer-backup.php
> - installer.php
> - wordfence-waf.php
> 
> Expect for a couple: What's the context behind license._**tet**_, and **i.php** @abhishekmorla?