### PR TITLE
Update LFI-gracefulsecurity-linux.txt to include older SSH key format "ECDSA" 

### DIFF
--- a/Fuzzing/LFI/LFI-gracefulsecurity-linux.txt
+++ b/Fuzzing/LFI/LFI-gracefulsecurity-linux.txt
@@ -244,6 +244,8 @@
 ~/.ssh/id_dsa.pub
 ~/.ssh/id_rsa
 ~/.ssh/id_rsa.pub
+~/.ssh/id_ecdsa
+~/.ssh/id_ecdsa.pub
 ~/.ssh/identity
 ~/.ssh/identity.pub
 ~/.viminfo


### PR DESCRIPTION
Includes older SSH key format "ECDSA"