### PR TITLE
added wso2 api manager endpoint /services/WorkflowCallbackService?wsdl

### DIFF
--- a/Discovery/Web-Content/wso2-enterprise-integrator.txt
+++ b/Discovery/Web-Content/wso2-enterprise-integrator.txt
@@ -72,3 +72,4 @@ carbon/yui/build/container/assets/skins/sam/container.css
 services/Version?tryit
 services/echo?wsdl2
 services/wso2carbon-sts?wsdl2
+services/WorkflowCallbackService?wsdl


### PR DESCRIPTION
I recently did a penetration test and used the list to identify available endpoints. While reading the documentation i found another interesting one that is available on many WSO2 API Manager instances without prior authentication and that exposes the HTTP endpoints of backend systems.