### PR TITLE
Typos in discovery files

### DIFF
--- a/Discovery/Web-Content/raft-large-directories-lowercase.txt
+++ b/Discovery/Web-Content/raft-large-directories-lowercase.txt
@@ -20733,7 +20733,7 @@ erosguide
 erotik
 err404
 errlog
-error_log
+error_log
 error_report
 errpage
 ertesito

--- a/Discovery/Web-Content/raft-large-directories.txt
+++ b/Discovery/Web-Content/raft-large-directories.txt
@@ -23999,7 +23999,7 @@ erosguide
 erotik
 err404
 errlog
-error_log
+error_log
 error_report
 errorhandler
 errpage

--- a/Discovery/Web-Content/raft-large-files-lowercase.txt
+++ b/Discovery/Web-Content/raft-large-files-lowercase.txt
@@ -23971,7 +23971,7 @@ directjob.html
 directlink.jsp
 directories.css
 directories1.html
-directory		e.g.
+directory
 directory-rss.xml
 directory2.dbm
 directory3.dbm

--- a/Discovery/Web-Content/raft-large-files.txt
+++ b/Discovery/Web-Content/raft-large-files.txt
@@ -25417,7 +25417,7 @@ directjob.html
 directlink.jsp
 directories.css
 directories1.html
-directory		e.g.
+directory
 directory-rss.xml
 directory2.dbm
 directory3.dbm


### PR DESCRIPTION
Some web-content discovery files have special characters that trigger an error while gobusting