### PR TITLE
fix of #377

### DIFF
--- a/Pattern-Matching/Source-Code-(PHP)/php-auditing.txt
+++ b/Pattern-Matching/Source-Code-(PHP)/php-auditing.txt
@@ -5,3 +5,4 @@ shell_exec
 popen
 proc_open
 pcntl_exec
+`


### PR DESCRIPTION
According to the issue #377 ``` `cmd` ``` was not included in [Pattern-Matching/Source-Code-(PHP)](https://github.com/danielmiessler/SecLists/tree/master/Pattern-Matching/Source-Code-(PHP)/php-auditing.txt)

This fix includes a singular backtick. According to the docs [here](https://www.php.net/manual/en/language.operators.execution.php), when text is enclosed in backticks php will execute it in a shell.

Since this is a pattern matching wordlist, a singular backtick should match this.