### PR TITLE
Quick fix for README updater

### DIFF
--- a/.bin/get-and-patch-readme-repository-details.py
+++ b/.bin/get-and-patch-readme-repository-details.py
@@ -51,11 +51,11 @@ DETAIL_USER_NOTICE_STRING=DETAIL_USER_NOTICE_STRING%(DETAILS_ANCHOR,final_size,e
 
 readme_contents=open("README.md").read()
 
-if re.match(DETAILS_ANCHOR_REGEX,readme_contents,flags=re.DOTALL):
-    print("[!] Error: No details anchor found!")
+if not re.search(DETAILS_ANCHOR_REGEX,readme_contents,flags=re.DOTALL):
+    print_err("README.md", "[!] Error: No details anchor found!")
     exit(2)
 
-readme_contents=re.sub(DETAILS_ANCHOR_REGEX,DETAIL_USER_NOTICE_STRING,readme_contents,flags=re.DOTALL)
+readme_contents=re.sub(DETAILS_ANCHOR_REGEX,DETAIL_USER_NOTICE_STRING,readme_contents,count=1,flags=re.DOTALL)
 open("README.md","w").write(readme_contents)
 
 print("[+] Wrote README.md!")

--- a/.bin/get-and-patch-readme-repository-details.py
+++ b/.bin/get-and-patch-readme-repository-details.py
@@ -20,6 +20,10 @@ Size of a complete clone of SecLists is currently at `%s`
 Cloning this repository should take %i-%i minutes at 5MB/s speeds.
 
 %s"""
+ERROR_STRING="::error file=%s,line=%s,col=%s,endColumn=%s::%s"
+
+def print_err(file,msg,line=1,col=1,endcol=1):
+    print(ERROR_STRING%(file,line,col,endcol,msg))
 
 size=requests.get(REPOSITORY_API%(REPOSITORY)).json()['size'] # Its in kb
 

--- a/.bin/get-and-patch-readme-repository-details.py
+++ b/.bin/get-and-patch-readme-repository-details.py
@@ -38,7 +38,7 @@ for i in suffixes:
         final_size[0]=final_size[0][:-3]
         final_size[2]=i
 
-final_size=str(round(Decimal('.'.join(final_size[:2])),1))+final_size[2]
+final_size="%s %s"%(str(round(Decimal('.'.join(final_size[:2])),1)),final_size[2])
 
 eta_lower_bound=int(str(size/5000/60).split('.')[0]) # Get whole number after decimal point
 eta_upper_bound=eta_lower_bound+1

--- a/.bin/get-and-patch-readme-repository-details.py
+++ b/.bin/get-and-patch-readme-repository-details.py
@@ -3,6 +3,7 @@
 # If you change the commit message you need to change .github/workflows/readme-updater.yml
 
 import requests,re
+from decimal import Decimal
 
 print("[+] Readme stats updater")
 
@@ -37,16 +38,7 @@ for i in suffixes:
         final_size[0]=final_size[0][:-3]
         final_size[2]=i
 
-trailing_nums=list(final_size[1])
-
-decimal_len=3-len(final_size[0])
-if int(trailing_nums[decimal_len])>=5:
-    trailing_nums[decimal_len-1]=str(int(trailing_nums[decimal_len-1])+1)
-
-trailing_nums=''.join(trailing_nums)
-trailing_nums=trailing_nums[:decimal_len]
-
-final_size=final_size[0]+'.'+trailing_nums+' '+final_size[2]
+final_size=str(round(Decimal('.'.join(final_size[:2])),1))+final_size[2]
 
 eta_lower_bound=int(str(size/5000/60).split('.')[0]) # Get whole number after decimal point
 eta_upper_bound=eta_lower_bound+1

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This project is maintained by [Daniel Miessler](https://danielmiessler.com/), [J
 
 ### Repository details
 
-Size of a complete clone of SecLists is currently at `969. MB`
+Size of a complete clone of SecLists is currently at `969.8 MB`
 
 Cloning this repository should take 3-4 minutes at 5MB/s speeds.
 


### PR DESCRIPTION
There is an edge case where if the size gets converted to standard form is three digits(for example `969`) there will be a `.` at the end of the string. 
This patch fixed this issue by using the decimal library to accurately round and adds some improvements such as improved logging in github actions