### PR TITLE
Add dict with path to config files of common CMS.

### DIFF
--- a/Discovery/Web-Content/CMS/cms-configuration-files.txt
+++ b/Discovery/Web-Content/CMS/cms-configuration-files.txt
@@ -1,0 +1,16 @@
+# This dict list the path to configuration files of different CMS
+# Drupal
+sites/default/settings.php
+sites/default/default.settings.php
+# Typo3
+config/system/settings.php
+config/system/additional.php
+typo3conf/system/settings.php
+typo3conf/system/additional.php
+# WorpPress
+wp-config.php
+# Joomla
+configuration.php
+# Magento
+app/etc/env.php
+app/etc/local.xml

--- a/Discovery/Web-Content/CMS/cms-configuration-files.txt
+++ b/Discovery/Web-Content/CMS/cms-configuration-files.txt
@@ -14,4 +14,3 @@ configuration.php
 # Magento
 app/etc/env.php
 app/etc/local.xml
-#

--- a/Discovery/Web-Content/CMS/cms-configuration-files.txt
+++ b/Discovery/Web-Content/CMS/cms-configuration-files.txt
@@ -14,3 +14,4 @@ configuration.php
 # Magento
 app/etc/env.php
 app/etc/local.xml
+#

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This project is maintained by [Daniel Miessler](https://danielmiessler.com/), [J
 
 ### Repository details
 
-Size of a complete clone of SecLists is currently at `1.0 GB`
+Size of a complete clone of SecLists is currently at `1.1 GB`
 
 Cloning this repository should take 3-4 minutes at 5MB/s speeds.
 


### PR DESCRIPTION
Hi,

This PR propose to add a dict with a list of the path to configuration files of different CMS.

💡 The goal is, for example, to check for the presence of a backup file of the configuration file for the current CMS, using for example this [dict of extensions](https://github.com/danielmiessler/SecLists/blob/master/Discovery/Web-Content/web-mutations.txt).

💻 Example of [usage](https://github.com/righettod/toolbox-pentest-web/blob/master/scripts/discover-cms-config-backup.sh).

💬 I have initiated the dict with popular CMS:

![image](https://github.com/danielmiessler/SecLists/assets/1573775/62343802-bc5c-4e6a-a0c8-23b33b76c653)


🌏 Sources used:

- https://www.drupal.org/forum/support/installing-drupal/2006-05-12/where-is-settingsphp-located
- https://www.simicart.com/blog/magento-2-database-configuration-file/
- https://amasty.com/knowledge-base/magento-1-2-database-config-file.html
- https://wordpress.org/documentation/article/editing-wp-config-php/
- https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/Configuration/ConfigurationFiles.html
- https://www.scalahosting.com/kb/where-is-configuration-php-in-joomla/
