### PR TITLE
Added a JWT key used in CVE-2023-51442

### DIFF
--- a/Passwords/scraped-JWT-secrets.txt
+++ b/Passwords/scraped-JWT-secrets.txt
@@ -3500,3 +3500,4 @@ zxcvz
 zxsde====zaaa
 Тайна
 密钥
+not so secret


### PR DESCRIPTION
GitHub's [advisory ](https://github.com/advisories/GHSA-wq59-4q6r-635r) of CVE-2023-51442 mentions the following:

```
A security vulnerability has been identified in Navidrome's subsonic endpoint, allowing for authentication bypass. This exploit enables unauthorized access to any known account by utilizing a JSON Web Token (JWT) signed with the key "not so secret".
```

This pull request adds the key involved in the CVE to the `scraped-JWT-secrets.txt` file