### PR TITLE
Changed issues templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -2,7 +2,7 @@
 name: 'Question'
 about: 'Anything that does not fit in the other categories'
 title: '[Question]: '
-labels: 'proposal'
+labels: 'question'
 assignees: ''
 ---
 

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request.md
@@ -1,7 +1,7 @@
 ---
 name: 'Pull request'
 about: 'Create a pull request to improve SecLists'
-title: '[Pull request]: TITLE'
+title: '[Pull request]: '
 labels: 'enhancement'
 assignees: ''
 


### PR DESCRIPTION
Using the label `question` is more suited for questions than `proposal` as sometimes the op wants clarifications than make a proposal.

For `pull_request.md`, I have removed the placeholder as other templates do not have them.