### PR TITLE
Add known OpenAPI paths

### DIFF
--- a/Discovery/Web-Content/swagger.txt
+++ b/Discovery/Web-Content/swagger.txt
@@ -48,3 +48,7 @@ api/v1/
 api/v2
 api/v3
 openapi.json
+openapi.yml
+openapi.yaml
+.well-known/openapi.json
+.well-known/openapi.yaml


### PR DESCRIPTION
Those OpenAPI paths have been found thanks to ChatGPT plugins.

Here some examples:
- https://github.com/dannyp777/ChatGPT-AI-Plugin-Manifest-Lists/blob/main/list-openapi-yaml.txt
- https://github.com/dannyp777/ChatGPT-AI-Plugin-Manifest-Lists/blob/main/list-ai-plugin-json.txt
