### PR TITLE
Add  several entries to the "common.txt" dictionary

### DIFF
--- a/Discovery/Web-Content/common.txt
+++ b/Discovery/Web-Content/common.txt
@@ -4398,6 +4398,7 @@ ver
 ver1
 ver2
 version
+version.json
 verwaltung
 vfs
 vi

--- a/Discovery/Web-Content/common.txt
+++ b/Discovery/Web-Content/common.txt
@@ -2989,6 +2989,7 @@ p7pm
 pa
 pack
 package
+package.json
 packaged
 packages
 packaging

--- a/Discovery/Web-Content/common.txt
+++ b/Discovery/Web-Content/common.txt
@@ -1280,6 +1280,8 @@ corpo
 corporate
 corporation
 corrections
+cosign.key
+cosign.pub
 count
 counter
 counters


### PR DESCRIPTION
Hi,

This PR add the following entries to the dict `common.txt`:
* `version.json` and `package.json` files
  * I often seen them exposed in case of an SPA.
* Add the default key pair files, `cosign.key` and `cosign.pub`,  generated by [cosign](https://github.com/sigstore/cosign)
  * This can happen, in case of mistake, during the deployment of an app from the base project folder.

Thanks a lot in advance 😃 