### PR TITLE
added swagger.yaml

### DIFF
--- a/Discovery/Web-Content/swagger.txt
+++ b/Discovery/Web-Content/swagger.txt
@@ -24,6 +24,7 @@ swagger.json
 swagger-ui.html
 swagger-ui.json
 swagger.yml
+swagger.yaml
 api/swagger
 api/swagger/
 api/swagger.json


### PR DESCRIPTION
This pull request adds a swagger.yaml file to the SecLists repository. The swagger.yaml file format is widely used to describe and document RESTful APIs, making it a valuable resource for security testing and bug hunting.