### PR TITLE
fix(docs): Corrected filename of the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,13 +7,16 @@ assignees: ''
 
 ---
 
+<!--- IMPORTANT --->
 <!--- Please make sure you've checked the CONTRIBUTING.md before creating a pull-request: https://github.com/danielmiessler/SecLists/blob/master/CONTRIBUTING.md -->
+<!--- IMPORTANT --->
 
 **Describe the added commits**
 <!--- A clear and concise description of what is being added to the repository. -->
 
 **Purpose of pull request**
 <!--- Tell us what made you decide to open a pull request. --->
+<!--- If you added a wordlist, describe what it could be used for --->
 
 **Source**
 <!--- Put/link the source here. -->


### PR DESCRIPTION
In its previous file position, the PR template would only be used if a contributor were to click a link specifically crafted to use that PR. With this PR, the PR template will be used every single time someone creates a pull request.

See: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository

In the future, when the UI for picking a PR template is added into github, this will be revised to add specific templates for "wordlist" PRs, "documentation" PRs, and "CI/CD" PRs. 

The relevant github discussion is https://github.com/orgs/community/discussions/42499