### PR TITLE
feat(wordlist): Created 'common_directories.txt' wordlist

### DIFF
--- a/.github/workflows/wordlist-updater_combined_directories.yml
+++ b/.github/workflows/wordlist-updater_combined_directories.yml
@@ -15,6 +15,7 @@ on:
       - 'Discovery/Web-Content/raft-large-directories.txt'
       - 'Discovery/Web-Content/directory-list-1.0.txt'
       - 'Discovery/Web-Content/combined_words.txt'
+      - 'Discovery/Web-Content/common_directories.txt'
 
 jobs:
   update_combined_directories:

--- a/Discovery/Web-Content/README.md
+++ b/Discovery/Web-Content/README.md
@@ -35,6 +35,7 @@ This list is a combination of the following wordlists:
 - raft-medium-directories.txt
 - raft-small-directories-lowercase.txt
 - raft-small-directories.txt
+- common_directories.txt
 
 ## dsstorewordlist.txt
 

--- a/Discovery/Web-Content/common_directories.txt
+++ b/Discovery/Web-Content/common_directories.txt
@@ -1,0 +1,4 @@
+gift-card
+insurance_applications
+shrdbms
+top-categories


### PR DESCRIPTION
**Describe the added commits**
Currently, all of the wordlists that compose `combined_directories.txt` are un-modifiable and do not allow new contributions to be added into them.
- `apache.txt` is server-specific
- `directory-list-*.txt` has an exclusive license
- `raft-*` is made from the frozen-in-time contents of [Google's raft](https://code.google.com/archive/p/raft/))

For these reasons, and to allow new contributions into the `combined_directories.txt` wordlist, I've created the `common_directories.txt` file. This will allow modifications into the  'combined_directories.txt' file without modifying any of the pre-existing wordlists.

**Purpose of pull request**
- Add a new wordlist: `combined_directories.txt`.
- Facilitate new contributions into the project.

**Source**
@ctflearner personal projects (see #1080)

**Additional context**
<!--- Add any other context about the problem/missing feature that you are fixing/solving here. 
Tag the issue here if applicable. -->
Co-authored-by: ctflearner <ctflearner@users.noreply.github.com>