### PR TITLE
Add debug.log file

### DIFF
--- a/Discovery/Web-Content/CMS/wordpress.fuzz.txt
+++ b/Discovery/Web-Content/CMS/wordpress.fuzz.txt
@@ -580,6 +580,7 @@ wp-config-sample.php
 wp-config.php
 wp-config.php.stage
 wp-content/
+wp-content/debug.log
 wp-content/index.php
 wp-content/plugins/
 wp-content/plugins/akismet/


### PR DESCRIPTION
Hi,

This PR add the file `wp-content/debug.log` to the WP fuzzing dictionary.

🤔Workflow validation error do not seems related to my update.

Sources:
* https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/
* https://www.acunetix.com/vulnerabilities/web/wordpress-debug-mode/  

Thanks in advance 😃 