### PR TITLE
Added reportserver directory at common.txt

### DIFF
--- a/Discovery/Web-Content/common.txt
+++ b/Discovery/Web-Content/common.txt
@@ -3527,6 +3527,7 @@ reports
 reports list
 repository
 repost
+reportserver
 reprints
 reputation
 req


### PR DESCRIPTION
**Purpose of pull request**
Added reportserver directory at common.txt, the reportserver directory is commonly seen when there's a SSRS. 
Mostly the directory listing is enabled by default.

**Source**
[https://learn.microsoft.com/en-us/sql/reporting-services/install-windows/configure-report-server-urls-ssrs-configuration-manager?view=sql-server-ver16](https://learn.microsoft.com/en-us/sql/reporting-services/install-windows/configure-report-server-urls-ssrs-configuration-manager?view=sql-server-ver16)
