### PR TITLE
feat(wordlist): Added more endpoints to common.txt

### DIFF
--- a/Discovery/Web-Content/common.txt
+++ b/Discovery/Web-Content/common.txt
@@ -2069,6 +2069,8 @@ header_logo
 headers
 headlines
 health
+health/live
+health/ready
 healthz
 healthcare
 hello
@@ -3974,6 +3976,7 @@ statistik
 stats
 statshistory
 status
+status/ready
 statusicon
 stock
 stoneedge


### PR DESCRIPTION
Those common paths are used for healthcheck and can leaked some technical data about the component and their technical dependencies.

Those paths can be found in several projects. There are common because there are mostly driven by some documentations or existing components with the same naming.

Here are some examples:
- https://www.keycloak.org/server/health
- https://docs.konghq.com/gateway/latest/production/monitoring/healthcheck-probes/