### PR TITLE
Add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+# Avoid having a newline ending txt files
+[*.txt]
+insert_final_newline = false


### PR DESCRIPTION
This PR is not a direct contribution to a list but more a proposal for an editorconfig ([editorconfig.org](https://editorconfig.org/)). Most of the modern Code Editor/IDE are supporting  this config format now.

It would be useful to avoid adding final newline by mistake because of an editor default config.
