### PR TITLE
feat(docs): Replace repository details with badges for better visibil…

### DIFF
--- a/.bin/get-and-patch-readme-repository-details.py
+++ b/.bin/get-and-patch-readme-repository-details.py
@@ -7,20 +7,12 @@ from decimal import Decimal
 
 print("[+] Readme stats updater")
 
+# Constants
+CONNECTION_SPEED_MBPS = 50  # Change this to set a different cloning speed (in Mbps)
 REPOSITORY_API="https://api.github.com/repos/%s"
 REPOSITORY="danielmiessler/SecLists"
-DETAILS_ANCHOR="<!--- details anchor -->"
-DETAILS_ANCHOR_REGEX=r"%s.*?%s"%(DETAILS_ANCHOR,DETAILS_ANCHOR)
-COMMIT_MESSAGE="[Github Action] Automated readme update."
-DETAIL_USER_NOTICE_STRING="""%s
-
-### Repository details
-
-Size of a complete clone of SecLists is currently at `%s`
-
-Cloning this repository should take %i-%i minutes at 5MB/s speeds.
-
-%s"""
+BADGE_REGEX=r"!\[Approx cloning time\]\(https://img\.shields\.io/badge/.*?\)"
+BADGE_TEMPLATE = f"![Approx cloning time](https://img.shields.io/badge/clone%%20time-~%%20%s%%20@%dMb/s-blue)"
 ERROR_STRING="::error file=%s,line=%s,col=%s,endColumn=%s::%s"
 
 def print_err(file,msg,line=1,col=1,endcol=1):
@@ -28,30 +20,38 @@ def print_err(file,msg,line=1,col=1,endcol=1):
 
 size=requests.get(REPOSITORY_API%(REPOSITORY)).json()['size'] # Its in kb
 
-suffixes=['MB','GB','TB']
-final_size=[str(size),"","KB"]
+# Calculate size in MB
+size_mb = Decimal(size) / 1024
 
-for i in suffixes:
-    if len(final_size[0])>3:
-        
-        final_size[1]=final_size[0][-3:]+final_size[1]
-        final_size[0]=final_size[0][:-3]
-        final_size[2]=i
+# Calculate cloning time for the defined connection speed (convert size to bits)
+cloning_time_seconds = int((size_mb * 8) / CONNECTION_SPEED_MBPS)
 
-final_size="%s %s"%(str(round(Decimal('.'.join(final_size[:2])),1)),final_size[2])
+# Cloning time seconds to minutes and seconds
+minutes = cloning_time_seconds // 60
+seconds = cloning_time_seconds % 60
 
-eta_lower_bound=int(str(size/5000/60).split('.')[0]) # Get whole number after decimal point
-eta_upper_bound=eta_lower_bound+1
+if minutes > 0:
+    cloning_time = f"{minutes}m%20{seconds}s"
+else:
+    cloning_time = f"{seconds}s"
 
-DETAIL_USER_NOTICE_STRING=DETAIL_USER_NOTICE_STRING%(DETAILS_ANCHOR,final_size,eta_lower_bound,eta_upper_bound,DETAILS_ANCHOR)
+# New badge string
+approx_cloning_time_badge = BADGE_TEMPLATE % (cloning_time, CONNECTION_SPEED_MBPS)
 
 readme_contents=open("README.md").read()
 
-if not re.search(DETAILS_ANCHOR_REGEX,readme_contents,flags=re.DOTALL):
-    print_err("README.md", "[!] Error: No details anchor found!")
+if not re.search(BADGE_REGEX,readme_contents,flags=re.DOTALL):
+    print_err("README.md", "[!] Error: No approx cloning time badge found!")
     exit(2)
 
-readme_contents=re.sub(DETAILS_ANCHOR_REGEX,DETAIL_USER_NOTICE_STRING,readme_contents,count=1,flags=re.DOTALL)
-open("README.md","w").write(readme_contents)
+# Update the badge in the README.md content
+new_readme_content = re.sub(
+    BADGE_REGEX,
+    approx_cloning_time_badge,
+    readme_contents,
+    count=1
+)
 
-print("[+] Wrote README.md!")
+open("README.md","w").write(new_readme_content)
+
+print(f"[+] Updated README.md with new cloning time badge at {CONNECTION_SPEED_MBPS}Mb/s!")

--- a/README.md
+++ b/README.md
@@ -8,15 +8,14 @@ This project is maintained by [Daniel Miessler](https://danielmiessler.com/), [J
 
 - - -
 
-<!--- details anchor -->
 
 ### Repository details
 
-Size of a complete clone of SecLists is currently at `1.8 GB`
+![Repo size](https://img.shields.io/github/repo-size/danielmiessler/SecLists.svg)
 
-Cloning this repository should take 6-7 minutes at 5MB/s speeds.
+<!-- This badge is automatically updated by a GitHub Action. Do not edit manually. -->
+![Approx cloning time](https://img.shields.io/badge/clone%20time-~%204m%2053s%20@50Mb/s-blue)
 
-<!--- details anchor -->
 
 - - -
 


### PR DESCRIPTION
**Purpose of pull request**
I replaced the repository details section in the main README with badges for `size`, `clone time` metrics. This makes the information more visually appealing and easier to grasp at a glance.

**Source**
Badges from: [shields.io](https://shields.io/)

**Additional context**
This change can be included under the issue #929 (Better Readmes) making important repository details more accessible and visually appealing. 
