### PR TITLE
feat(wordlist): Add IIS default page and image files.

### DIFF
--- a/Discovery/Web-Content/IIS.fuzz.txt
+++ b/Discovery/Web-Content/IIS.fuzz.txt
@@ -80,6 +80,8 @@ iissamples/exair/howitworks/Codebrws.asp
 iissamples/sdk/asp/docs/codebrw2.asp
 iissamples/sdk/asp/docs/codebrws.asp
 iissamples/sdk/asp/docs/CodeBrws.asp
+iisstart.htm
+iisstart.png
 images/
 imprimer.asp
 includes/adovbs.inc


### PR DESCRIPTION
**Purpose of pull request**

Hi,

This PR add the default HTML and PNG file present at the root of an IIS server to the IIS fuzzing dictionary.

Thanks in advance 😃 

**Source**

* https://learn.microsoft.com/en-us/answers/questions/640298/how-do-i-disable-this-feature
* https://learn.microsoft.com/en-us/iis/configuration/system.webserver/defaultdocument/

**Additional context**

None
