### PR TITLE
feat(wordlist): Content type application/x-httpd-php

### DIFF
--- a/Discovery/Web-Content/web-all-content-types.txt
+++ b/Discovery/Web-Content/web-all-content-types.txt
@@ -1463,6 +1463,7 @@ application/x-gnumeric
 application/x-google-protobuf
 application/x-gtar
 application/x-hdf
+application/x-httpd-php
 application/x-java-jnlp-file
 application/x-latex
 application/x-mobipocket-ebook


### PR DESCRIPTION
**Purpose of pull request**
**CVE-2024-39884** affecting **Apache HTTP Server 2.4.60** is triggered by a legacy content-type: `application/x-httpd-php`. This content type was missing from **Discovery/Web-Content/web-all-content-types.txt**

**Source**

https://www.cve.news/cve-2024-39884/
https://nvd.nist.gov/vuln/detail/cve-2024-39884

