### PR TITLE
Update ssh-betterdefaultpasslist.txt

### DIFF
--- a/Passwords/Default-Credentials/ssh-betterdefaultpasslist.txt
+++ b/Passwords/Default-Credentials/ssh-betterdefaultpasslist.txt
@@ -132,3 +132,4 @@ root:reverse
 zyfwp:PrOw!aN_fXp
 manage:!manage
 monitor:!monitor
+root:password


### PR DESCRIPTION
add root:password combination to ssh default list - missed sometimes in pentests this comb when using the wordlist