### PR TITLE
Add python pip related files

### DIFF
--- a/Discovery/Web-Content/common.txt
+++ b/Discovery/Web-Content/common.txt
@@ -300,6 +300,8 @@ Office
 P
 PDF
 PHP
+Pipfile
+Pipfile.lock
 PMA
 Pages
 People


### PR DESCRIPTION
**Purpose of pull request**

Hi,

This PR propose to add the following **pip** related files:

* `Pipfile`
* `Pipfile.lock`

Such files can be present, by mistake, after the deployment of a python-based web app and, then, can provides information about:
* External modules used and then potential vulnerable ones.
* Exposure to [dependency confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610) attacks in case of internal modules used.

**Source**

* https://pipenv.pypa.io/en/latest/pipfile.html

**Additional context**

None.
