### PR TITLE
Added url used in CVE-2025-31324 to urls-SAP.txt

### DIFF
--- a/Discovery/Web-Content/URLs/urls-SAP.txt
+++ b/Discovery/Web-Content/URLs/urls-SAP.txt
@@ -1,3 +1,4 @@
+developmentserver/metadatauploader
 rep/build_info.html
 rep/build_info.jsp
 run/build_info.html


### PR DESCRIPTION
**Purpose of pull request**
SAP NetWeaver AS Java Visual Composer Metadata Uploader is vulnerable according to CVE-2025-31324. JSP webshells have been identified to be uploaded in active exploitation.

**Source**
https://reliaquest.com/blog/threat-spotlight-reliaquest-uncovers-vulnerability-behind-sap-netweaver-compromise/
