### PR TITLE
feat(wordlist): Added kutzooi to the list of Dutch swear words

### DIFF
--- a/Miscellaneous/List-Of-Swear-Words/nl.txt
+++ b/Miscellaneous/List-Of-Swear-Words/nl.txt
@@ -89,6 +89,7 @@ kontneuken
 krentekakker
 kut
 kuttelikkertje
+kutzooi
 kwakkie
 liefdesgrot
 lul


### PR DESCRIPTION
<!--- IMPORTANT --->
<!--- Please make sure you've checked the CONTRIBUTING.md before creating a pull-request: https://github.com/danielmiessler/SecLists/blob/master/CONTRIBUTING.md -->
<!--- IMPORTANT --->

**Purpose of pull request**
I see the common Dutch swear word "kutzooi" was not included in the list of Dutch swear words. This adds that word.

**Source**
<!--- Put/link the source here. -->

**Additional context**
<!--- Add any other context about the problem/missing feature that you are fixing/solving here. -->
<!--- Tag the issue here if applicable. -->
