### PR TITLE
Add default SSH password "padmin:padmin" for IBM Power Systems

### DIFF
--- a/Passwords/Default-Credentials/ssh-betterdefaultpasslist.txt
+++ b/Passwords/Default-Credentials/ssh-betterdefaultpasslist.txt
@@ -133,3 +133,4 @@ root:reverse
 zyfwp:PrOw!aN_fXp
 manage:!manage
 monitor:!monitor
+padmin:padmin

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This project is maintained by [Daniel Miessler](https://danielmiessler.com/), [J
 ![Repo size](https://img.shields.io/github/repo-size/danielmiessler/SecLists.svg)
 
 <!-- This badge is automatically updated by a GitHub Action. Do not edit manually. -->
-![Approx cloning time](https://img.shields.io/badge/clone%20time-~%205m%2055s%20@50Mb/s-blue)
+![Approx cloning time](https://img.shields.io/badge/clone%20time-~%205m%2053s%20@50Mb/s-blue)
 
 
 - - -

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This project is maintained by [Daniel Miessler](https://danielmiessler.com/), [J
 ![Repo size](https://img.shields.io/github/repo-size/danielmiessler/SecLists.svg)
 
 <!-- This badge is automatically updated by a GitHub Action. Do not edit manually. -->
-![Approx cloning time](https://img.shields.io/badge/clone%20time-~%205m%2053s%20@50Mb/s-blue)
+![Approx cloning time](https://img.shields.io/badge/clone%20time-~%205m%2055s%20@50Mb/s-blue)
 
 
 - - -


### PR DESCRIPTION
`padmin:padmin` is a common default SSH password we see on internal pentests, particularly for fortune 500s.

FYSA @MarcusAmes 