### PR TITLE
fix(wordlist): Fixed encoding in "100k-most-used-passwords-NCSC"

### DIFF
--- a/Passwords/Common-Credentials/100k-most-used-passwords-NCSC.txt
+++ b/Passwords/Common-Credentials/100k-most-used-passwords-NCSC.txt
@@ -1148,7 +1148,7 @@ southside1
 soccer10
 zoosk
 maryjane
-Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…
+пїЅпїЅпїЅпїЅпїЅпїЅ
 brenda
 rebecca1
 baller1
@@ -1367,7 +1367,7 @@ PASSWORD
 1234560
 newlife
 chris123
-ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½
+++++++
 123qaz
 leslie
 jimmy1
@@ -2468,7 +2468,7 @@ wrestling1
 private
 potato
 special
-Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…
+пїЅпїЅпїЅпїЅпїЅпїЅпїЅ
 good
 manuela
 cherokee
@@ -2852,7 +2852,7 @@ charlene
 adam
 emilie
 5678
-Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…
+пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ
 dickhead1
 letter
 123456789k
@@ -2925,7 +2925,7 @@ kristen1
 dexter1
 bella123
 bitch2
-ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½
++++++++
 liberty1
 rolltide
 madmax
@@ -3308,7 +3308,7 @@ billabong
 777888
 annette
 bernie
-ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½
+++++++++
 blossom
 chase1
 williams1
@@ -4443,7 +4443,7 @@ calvin1
 sirius
 wordpass1
 titans
-Ñ
+я
 rockyou
 assass
 sandeep
@@ -4459,11 +4459,11 @@ mushroom
 love33
 jesucristo
 rebelde
-ï¿½ï¿½
+
 stuart
 deedee1
 w1983a
-Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…
+пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ
 deniska
 babyblue1
 mouse
@@ -4993,7 +4993,7 @@ bigfoot
 sunshine12
 catfish1
 foxpass
-Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…
+пїЅпїЅпїЅпїЅпїЅ
 1230123
 5
 iloveu123
@@ -5101,7 +5101,7 @@ fuckthis1
 nancy1
 flames
 goodgirl
-ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½
++++++++++
 manunited
 qqqq
 123450
@@ -5273,7 +5273,7 @@ search
 castro
 lovelife1
 eastside
-ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½
++++++
 caramelo
 kristi
 z1x2c3v4
@@ -5596,7 +5596,7 @@ garcia1
 miley1
 james2
 ballet
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 brigitte
 baker3
 ethan
@@ -5925,7 +5925,7 @@ stingray
 katarina
 bonita1
 fuckyou13
-ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½
+++
 1968
 univers2l
 patriot
@@ -7433,7 +7433,7 @@ ashley11
 astonvilla
 durango1
 snoopy2
-ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
++
 angel16
 jeffery1
 latina1
@@ -7646,7 +7646,7 @@ lucky12
 josefina
 tommy123
 babygirl09
-Nï¿½odefinido
+Nodefinido
 201010
 classic1
 bunny123
@@ -8490,7 +8490,7 @@ smoking
 ripper
 winchester
 holmes
-Ð¹Ñ†ÑƒÐºÐµÐ½
+йцукен
 love4you
 dilbert
 sexy07
@@ -8498,7 +8498,7 @@ sexy07
 z123456789
 duckie
 doctor1
-ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
++
 number5
 rashmi
 18n28n24a5
@@ -8704,7 +8704,7 @@ lalaland
 hyderabad
 liverpoolfc
 20112011
-Ð¿Ð°Ñ€Ð¾Ð»ÑŒ
+пароль
 nelly
 soccer08
 nokia3310
@@ -8982,7 +8982,7 @@ april16
 september9
 joseph12
 lickme
-Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…
+пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ
 hjccbz
 harriet
 lopez1
@@ -9703,7 +9703,7 @@ polaris1
 loretta
 kasia
 theatre
-Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…
+пїЅпїЅпїЅпїЅ
 alexis09
 sexygurl1
 monty
@@ -9986,7 +9986,7 @@ password33
 lobster1
 2gether
 alfredo1
-ï¿½+ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½
+++
 22
 chris14
 radhika
@@ -10110,7 +10110,7 @@ december25
 nomore
 6543211
 jasmine3
-Ð»ÑŽÐ±Ð»ÑŽ
+люблю
 che
 blaze
 poohbear12
@@ -10279,7 +10279,7 @@ diamant
 florence1
 geneva
 march10
-ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½
+++++
 kingfisher
 gfhjkmgfhjkm
 tennessee1
@@ -10362,7 +10362,7 @@ pooh123
 money10
 yesterday
 chris5
-ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½
+++++++++++
 r1cd38d
 mamacita
 rosemary1
@@ -10447,7 +10447,7 @@ sheena1
 user888
 alex22
 ddddd
-Ð»ÑŽÐ±Ð¾Ð²ÑŒ
+любовь
 chris22
 football6
 hopper
@@ -11954,7 +11954,7 @@ chinedu
 fucker69
 him666
 888
-Ð¿Ñ€Ð¸Ð²ÐµÑ‚
+привет
 tornado1
 dinosaur1
 julio
@@ -12659,7 +12659,7 @@ shahrukh
 ananda
 march29
 demon1q2w3e4r
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 marie3
 baggies1
 method
@@ -13406,7 +13406,7 @@ edinburgh
 community
 johnboy
 mouse123
-ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½+
+++
 static
 slipknot12
 wheels
@@ -15176,7 +15176,7 @@ fat
 taylor5
 presto
 joshua10
-ï¿½+ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½
+++
 beachbum
 cocoloco
 manson666
@@ -15442,7 +15442,7 @@ mckenna
 homers
 asdfghjkl;
 dragon6
-ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
++
 lonnie
 socrate
 ashlyn
@@ -15669,7 +15669,7 @@ zoe123
 totoro
 counterstrike
 blue16
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 tippy1
 phuong
 fullmetal
@@ -16248,7 +16248,7 @@ shandy
 yomomma
 barca
 terrys
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 198411
 shell
 sanjuan
@@ -16381,7 +16381,7 @@ dozer1
 rabbits
 27272727
 mivida
-ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
++
 uuuuuu
 angelface
 rampage
@@ -17045,7 +17045,7 @@ midnite
 jessica69
 t36473647
 Sebastian
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 sincere1
 chadwick
 prodigy1
@@ -17799,7 +17799,7 @@ doodlebug1
 aquila
 nathan11
 Football1
-Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…
+пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ
 M01759766727
 sandie
 1867sb
@@ -19414,7 +19414,7 @@ veri1234
 lizbeth
 pop168168
 dalbas73
-Ð½Ð°Ñ‚Ð°ÑˆÐ°
+наташа
 pinky2
 2246926
 frisco1
@@ -20258,7 +20258,7 @@ neptune1
 7eleven
 110070
 bryce
-ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
++
 gayboy
 joshua22
 justin4
@@ -21141,7 +21141,7 @@ tiger21
 happy6
 fox
 calendar
-ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½
++++++++++++
 ama
 chester123
 1101
@@ -21756,7 +21756,7 @@ skull1
 tomato1
 malibog
 im
-1ï¿½2ï¿½ï¿½3ï¿½ï¿½
+123
 passwords1
 dancer13
 pokemons
@@ -22103,7 +22103,7 @@ privacy1
 nbvjif
 juliet123
 freedom09
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 dragon14
 malaya
 campus
@@ -22115,7 +22115,7 @@ jaguars
 lover01
 obama09
 bre
-Ð¼Ð°ÐºÑÐ¸Ð¼
+максим
 123456789@
 alex88
 k47Rizxt2G
@@ -22593,7 +22593,7 @@ makoto
 joshua08
 wibble
 austin99
-123ï¿½ï¿½ï¿½ï¿½ï¿½
+123
 elena123
 brandon15
 peaches12
@@ -24264,7 +24264,7 @@ ronaldinho10
 5482
 shocker
 sleeping
-ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½
+++
 august08
 minou
 shithappens
@@ -24284,7 +24284,7 @@ stas
 aa12345
 kikay
 3monkeys
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 avery
 raerae
 1hotdog
@@ -24415,7 +24415,7 @@ rubber1
 rockwell
 password91
 getalife
-ÐºÑ€Ð¸ÑÑ‚Ð¸Ð½Ð°
+кристина
 halo23
 bailey10
 xboxlive1
@@ -24587,7 +24587,7 @@ patrick5
 aka1908
 anthony69
 Computer1
-123456ï¿½
+123456
 fingers1
 infamous
 pippin1
@@ -24874,7 +24874,7 @@ korn666
 del
 jesus09
 junior7
-Ð°Ð½Ð´Ñ€ÐµÐ¹
+андрей
 noemi
 rebeka
 happyme
@@ -24949,7 +24949,7 @@ jayden09
 rene
 virgilio
 lmao123
-ÑÐ¾Ð»Ð½Ñ‹ÑˆÐºÐ¾
+солнышко
 kush420
 123400
 titoune
@@ -25162,7 +25162,7 @@ shorty10
 rebecca123
 224422
 nachos
-ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½
+++
 1478520
 shamus
 420smoke
@@ -25185,7 +25185,7 @@ guyana1
 hottie6
 chrisb
 jessie01
-Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…
+пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ
 3344521
 misskitty1
 lalala12
@@ -25284,7 +25284,7 @@ hockey33
 aremania
 pinnacle
 glory
-Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…@mail.ru
+пїЅпїЅпїЅпїЅпїЅпїЅ@mail.ru
 quinton
 lexi
 bigdog2
@@ -25296,7 +25296,7 @@ Soccer
 dancer87
 kotek
 sweet7
-Ð¼Ð°Ñ€Ð¸Ð½Ð°
+марина
 guitar3
 august6
 screwyou
@@ -25451,7 +25451,7 @@ CARLOS
 school11
 dom123
 samantha13
-ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½@mail.ru
+++++++@mail.ru
 lerochka
 apple23
 560093
@@ -26456,7 +26456,7 @@ himmel
 hope12
 lori
 ilovejason
-Ð°Ð½Ð°ÑÑ‚Ð°ÑÐ¸Ñ
+анастасия
 bailey3
 vorona
 knowledge1
@@ -27629,7 +27629,7 @@ grenoble
 101081
 jayden12
 cochon
-1ï¿½2ï¿½ï¿½3ï¿½ï¿½4ï¿½
+1234
 nena12
 andrew07
 dakota13
@@ -27907,7 +27907,7 @@ schnuffi
 user123
 130690
 happy23
-contrase+ï¿½a
+contrase+a
 info123
 bububu
 shine1
@@ -28432,7 +28432,7 @@ babygirl#1
 mamabear
 100289
 brittany7
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 candy69
 baby12345
 belize
@@ -28844,7 +28844,7 @@ dolphin12
 chris05
 zombie666
 buster69
-ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½
+++++++++++++
 1580@welcamino
 martinka
 246246
@@ -28865,7 +28865,7 @@ joseph10
 daisydog1
 ilovelucy1
 DIAMOND
-Ð â„–Ð¡â€ Ð¡Ñ“Ð Ñ”Ð ÂµÐ Ð…
+Р№С†СѓРєРµРЅ
 skills
 zxcvvcxz
 redskin
@@ -28947,7 +28947,7 @@ closer
 scuba
 simplicity
 reese
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 getmoney08
 media
 animal123
@@ -30196,7 +30196,7 @@ cheshire
 jacinta
 110007
 brookie1
-Ð°Ð»ÐµÐºÑÐ°Ð½Ð´Ñ€
+александр
 sheriff1
 lakeview
 magalie
@@ -30389,7 +30389,7 @@ milagro
 franks
 william10
 sparky01
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 100387
 neil
 lostsoul
@@ -30777,7 +30777,7 @@ pololo
 laurine
 candy6
 1229
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 cool99
 carwash
 sexytime1
@@ -30978,7 +30978,7 @@ batman6
 gasman
 diver1
 changeit
-ï¿½+ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+++
 oladimeji
 oluwaseyi
 gutierrez1
@@ -31429,7 +31429,7 @@ policy1
 gohan
 ilovebrian
 drunk1
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 ratman
 chandra1
 230486
@@ -31933,7 +31933,7 @@ jasmine!
 carmelita
 satelite
 loverboy2
-ï¿½+ï¿½ï¿½+ï¿½ï¿½+ï¿½ï¿½+ï¿½
+++++
 james101
 19071988
 ndaCebx2wx
@@ -32250,7 +32250,7 @@ ellabella
 shorty16
 superman09
 star88
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½:
++++:
 onions
 arsenal7
 jasmin12
@@ -32458,7 +32458,7 @@ summit1
 dave1234
 jose01
 mymother1
-Ð»ÑŽÐ±Ð¸Ð¼Ð°Ñ
+любимая
 testqa1
 aviator
 por
@@ -32469,7 +32469,7 @@ dimon
 karissa1
 blade55
 Summer11
-Ð»ÑŽÐ±Ð¸Ð¼Ñ‹Ð¹
+любимый
 licker
 green!
 sailboat1
@@ -32653,7 +32653,7 @@ profesional
 z123456z
 daisy7
 hewitt
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½
++
 226001
 shawn12
 246801
@@ -33339,7 +33339,7 @@ brittany3
 kiana1
 261187
 johnny3
-Ð²Ð¸ÐºÑ‚Ð¾Ñ€Ð¸Ñ
+виктория
 ranger2
 janicka
 1914
@@ -33536,7 +33536,7 @@ PATRICIA
 passions1
 181187
 shop
-ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
++
 doughnut
 loop1206ssdsff
 pavithra
@@ -33551,7 +33551,7 @@ mustang9
 221285
 punkie
 2m66xF2AJT
-1Ð¹2Ñ†3Ñƒ
+1й2ц3у
 akanksha
 barca1
 bidemi
@@ -33667,7 +33667,7 @@ almendra
 toolman
 meryem
 301088
-ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½
++
 dragon09
 pokemon8
 apricot
@@ -34515,7 +34515,7 @@ chelsea9
 money18
 matt23
 werwolf
-Ð¼Ð°Ð¼Ð¾Ñ‡ÐºÐ°
+мамочка
 nigga4life
 25051988
 orange99
@@ -34564,7 +34564,7 @@ needjob
 ilona
 18811881
 vbktyf
-ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½
++
 481516
 151087
 230287
@@ -34589,7 +34589,7 @@ dixiedog
 dashadasha
 johnny11
 jk1234
-ï¿½+ï¿½ï¿½+ï¿½ï¿½ï¿½+ï¿½ï¿½
++++
 nicaragua1
 1iloveu
 wilhelm
@@ -34776,7 +34776,7 @@ malayalam
 ktm125
 maggot1
 siegheil
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½
++
 12041986
 hello09
 100884
@@ -35261,7 +35261,7 @@ twins123
 alex007
 1candy
 dasha1
-Ð¡Ð
+СЏ
 101295
 anelka
 sunmoon
@@ -35541,7 +35541,7 @@ vendetta1
 230785
 21051991
 taratata
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 azerty123456
 sunshine88
 pasta
@@ -36203,7 +36203,7 @@ nirvana7
 angels13
 angel.
 20071988
-Ð½Ð¸ÐºÐ¸Ñ‚Ð°
+никита
 iopiop
 30061987
 austin6
@@ -36347,7 +36347,7 @@ andrea.
 lilman12
 patty123
 titina
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 010688
 Welkom01
 tigger24
@@ -36885,7 +36885,7 @@ scott2
 amoroso
 bubba69
 edwin123
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 11031985
 271187
 purple89
@@ -37087,7 +37087,7 @@ rhino
 191188
 fkm:
 cnhtrjpf
-Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…
+пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ
 antelope
 vfvfbgfgf
 packer1
@@ -37806,7 +37806,7 @@ april01
 stevens1
 loser21
 311090
-123Ð¹Ñ†Ñƒ
+123йцу
 falling
 010888
 02081986
@@ -38043,7 +38043,7 @@ manoj
 andrei1
 bunny13
 someday1
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 sophie13
 tujheirf
 teagan
@@ -38341,7 +38341,7 @@ versus
 thelove
 311085
 flawless1
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½
++
 12011985
 231284
 thuglife2
@@ -39111,7 +39111,7 @@ survival
 darkness12
 cutiepie3
 wwwaaabbb
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 22051986
 251282
 22061990
@@ -39201,7 +39201,7 @@ Gandalf
 jesus6
 asaasa
 famous12
-1ï¿½2ï¿½ï¿½3ï¿½ï¿½4ï¿½5ï¿½ï¿½
+12345
 john117
 shadow0
 24101989
@@ -39889,7 +39889,7 @@ mymoney1
 110030
 zoom
 110185
-ï¿½+ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+++
 city
 20132013
 februari
@@ -40363,7 +40363,7 @@ sugipula
 lkjlkj
 sister12
 xcvbnm
-ï¿½ï¿½ï¿½ï¿½ï¿½
+
 amyamy
 playbill
 donut1
@@ -40440,7 +40440,7 @@ chestnut1
 130284
 14061991
 nodoubt1
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½
+++
 ronny
 osprey
 311282
@@ -40686,7 +40686,7 @@ magneto
 wwe
 badboyz
 death69
-Ð Ñ—Ð Â°Ð¡Ð‚Ð Ñ•Ð Â»Ð¡ÐŠ
+РїР°СЂРѕР»СЊ
 sterne
 dylan13
 852741963
@@ -41557,7 +41557,7 @@ tigger8
 blondie!
 mandragora
 14041990
-123456789ï¿½
+123456789
 15061990
 oliver3
 110010
@@ -41870,7 +41870,7 @@ cameron6
 pretty6
 fred01
 mirror1
-ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
++
 1596357
 1spiderman
 18011987
@@ -43678,7 +43678,7 @@ jesus20
 23121989
 197373
 dfczdfcz
-ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½
++++++++++++++
 maja
 monster01
 29091992
@@ -43787,7 +43787,7 @@ like
 1301
 pickle12
 craig123
-Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…
+пїЅпїЅпїЅ
 mybabe
 251191
 3000
@@ -44683,7 +44683,7 @@ celtic1967
 hondas1
 amazonas
 26051986
-ï¿½+ï¿½ï¿½+ï¿½ï¿½ï¿½
+++
 truand
 slipknot11
 daniel26
@@ -44785,7 +44785,7 @@ kaitlynn
 shorty08
 duchesse
 26011987
-ÐºÐ°ÐºÐ°ÑˆÐºÐ°
+какашка
 030392
 thomas05
 sexy2008
@@ -45096,7 +45096,7 @@ hattie1
 playboy21
 jerry2
 30041986
-Ð¹Ñ†ÑƒÐºÐµÐ½Ð³ÑˆÑ‰Ð·
+йцукенгшщз
 laura01
 13071985
 513513
@@ -45620,7 +45620,7 @@ redlight
 softball19
 alexander.
 mohawk1
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 almighty5
 courtney3
 catalunya
@@ -45683,7 +45683,7 @@ jasmin3
 orchid1
 16101992
 241092
-ÑÐµÑ€Ð³ÐµÐ¹
+сергей
 22121982
 happy09
 apples22
@@ -46264,7 +46264,7 @@ spring01
 19091992
 passw
 011288
-Ñ‚Ð°Ñ‚ÑŒÑÐ½Ð°
+татьяна
 arselect
 foxyroxy
 badgurl
@@ -46304,7 +46304,7 @@ courtney7
 180390
 honey6
 realdeal
-Ð¯
+Я
 raiders#1
 kellyann
 20021992
@@ -46365,7 +46365,7 @@ luckey1
 28021989
 fuzzy123
 summers1
-ï¿½
+
 28061988
 1234555
 alena1
@@ -46767,7 +46767,7 @@ rasheed1
 surfboard
 180880
 rewind
-1Ð¹2Ñ†3Ñƒ4Ðº
+1й2ц3у4к
 constanta
 emilyrose
 27031992
@@ -46799,7 +46799,7 @@ mexicana
 keens_1
 Fktrctq
 firedragon
-Ð¼Ð°Ð»Ñ‹ÑˆÐºÐ°
+малышка
 slapper
 445544
 221280
@@ -47180,7 +47180,7 @@ nb
 triangle1
 frogman1
 saruman
-ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½
++++
 blunts420
 17051984
 redstar1
@@ -47207,7 +47207,7 @@ sho
 blue26
 ripper6
 rosie12
-Ð¹Ñ†ÑƒÐºÐµÐ½Ð³ÑˆÑ‰Ð·Ñ…ÑŠ
+йцукенгшщзхъ
 volvos80
 kevin16
 rossignol
@@ -47796,7 +47796,7 @@ sarahh
 mustang09
 tokyo1
 perrita
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½+
+++
 098
 01051989
 cliff1
@@ -47896,7 +47896,7 @@ shiva123
 juve
 nirvana!
 kylie123
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 28021987
 shakur1
 freelander
@@ -48349,7 +48349,7 @@ march03
 thrasher1
 14101990
 170991
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 12111992
 198327
 20011990
@@ -48570,7 +48570,7 @@ juneau
 jessica25
 28111988
 cecil
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 050490
 melissa8
 150980
@@ -49837,7 +49837,7 @@ mama123456
 29081985
 perrito1
 precious3
-ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
++
 element11
 scooter13
 floriana
@@ -50122,7 +50122,7 @@ hotguy
 fishers
 forever17
 poopy!
-ÑÑ‡ÑÐ¼Ð¸Ñ‚
+ячсмит
 woodrow1
 13051984
 jojo10
@@ -50679,7 +50679,7 @@ sexyness1
 forsythe
 answer1
 fucker13
-12345ï¿½
+12345
 1lucky
 Veronica
 rouge
@@ -50866,7 +50866,7 @@ threekids3
 dima1991
 francis123
 boohoo1
-Ð°Ð»ÐµÐºÑÐµÐ¹
+алексей
 ABcd1234
 Carolina
 pink44
@@ -51274,7 +51274,7 @@ usuck
 lol000
 110381
 brewers1
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 wmilan
 10181018
 fed
@@ -51688,7 +51688,7 @@ capricorno
 baseball02
 1florida
 freedom201
-Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…
+пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ
 011290
 cutebaby
 bobby22
@@ -52803,7 +52803,7 @@ lollypop2
 mary01
 kinkin
 shadowfax
-ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+++
 keebler
 bass12
 120293
@@ -52882,7 +52882,7 @@ fl0wer
 03121986
 whitedog
 000aaa
-Ð»ÑŽÐ±Ð»ÑŽÑ‚ÐµÐ±Ñ
+люблютебя
 13011985
 090590
 04011991
@@ -54071,7 +54071,7 @@ skater4lif
 pudge1
 snowing
 060680
-ÐµÐºÐ°Ñ‚ÐµÑ€Ð¸Ð½Ð°
+екатерина
 03021992
 francisco2
 /.,mnbvcxz
@@ -54309,7 +54309,7 @@ chorizo
 mafiawars1
 010884
 adrian3
-ÑÐ¾Ð»Ð½Ñ†Ðµ
+солнце
 270707
 grandma123
 198198
@@ -54437,7 +54437,7 @@ ak47ak47
 666666m
 123456_
 110182
-ÑÑ‚ÐµÐ±ÑÐ»ÑŽÐ±Ð»ÑŽ
+ятебялюблю
 jasmine.
 deadpool1
 Helena
@@ -54598,7 +54598,7 @@ il0v3y0u
 tigger101
 260284
 sondra
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 231293
 111972
 72chevy
@@ -55098,7 +55098,7 @@ blondie12
 zidane5
 140183
 austin00
-Ñ€Ð¾Ð¼Ð°ÑˆÐºÐ°
+ромашка
 wouter
 chauncey1
 06091988
@@ -55280,7 +55280,7 @@ gabriel22
 khan1234
 311281
 lupe123
-ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
++
 aleksej
 63636363
 cobblers
@@ -55374,7 +55374,7 @@ skate69
 motomoto
 beleza
 jeepjeep
-ÑÑ‡ÑÐ¼Ð¸Ñ‚ÑŒ
+ячсмить
 horses01
 161080
 feanor
@@ -56311,7 +56311,7 @@ arenas
 daniela2
 freak12
 7979
-ÐºÐ¾Ð½Ñ‚Ð°ÐºÑ‚
+контакт
 11261126
 blood4
 pooh08
@@ -56496,7 +56496,7 @@ monkey04
 1922
 01061980
 audition
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 23091984
 troia
 anabella
@@ -56575,7 +56575,7 @@ xpressmusic
 caroline2
 coaster
 25111992
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 191291
 naruto0
 240792
@@ -57507,7 +57507,7 @@ dracon
 20051981
 grihan
 hat123
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½-ï¿½ï¿½ï¿½ï¿½ï¿½
+-
 3344
 lookup
 ana1234
@@ -58094,7 +58094,7 @@ rangers1690
 1babydoll
 olivia!
 1qwerty7
-ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
++
 wolverine2
 lololol1
 carbon12
@@ -58686,7 +58686,7 @@ roleplay1
 gemini123
 johnson3
 hellomate
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 shopaholic
 1726354
 pineapple3
@@ -58747,7 +58747,7 @@ nayara
 280982
 190383
 qqqq1234
-Ð²ÐºÐ¾Ð½Ñ‚Ð°ÐºÑ‚Ðµ
+вконтакте
 bestie1
 02071981
 tunnel
@@ -59294,7 +59294,7 @@ hunter20
 dope
 hailee1
 2402
-ÑÐ²ÐµÑ‚Ð»Ð°Ð½Ð°
+светлана
 lizzard1
 anarchy666
 112233z
@@ -59661,7 +59661,7 @@ pearljam10
 taylor1234
 unicorn2
 pretinha
-ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
++
 190982
 boknoy
 200280
@@ -60152,7 +60152,7 @@ mimi14
 lithuania
 p12345678
 198019
-ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½
+++++++++++++++
 riley01
 bassist1
 dakota08
@@ -61892,7 +61892,7 @@ super4
 porky
 honey18
 holstein
-Ð Â»Ð¡Ð‹Ð Â±Ð Ñ•Ð Ð†Ð¡ÐŠ
+Р»СЋР±РѕРІСЊ
 221983
 mathematic
 john20
@@ -62403,7 +62403,7 @@ JESSIE
 777aaa
 booboo8
 200777
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 HEATHER
 llama123
 02021976
@@ -63489,7 +63489,7 @@ p7678287
 chiken1
 17011701
 777555666
-1Ð¹2Ñ†3Ñƒ4Ðº5Ðµ
+1й2ц3у4к5е
 saravana
 26041993
 1472
@@ -63835,7 +63835,7 @@ austin95
 Undertaker
 songoku1
 bliss1
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½
++
 helper1
 snakebite
 220478
@@ -64631,7 +64631,7 @@ iloveyou90
 010982
 1qazXSW@
 again
-Ð´Ð¼Ð¸Ñ‚Ñ€Ð¸Ð¹
+дмитрий
 orpheus
 231980
 240579
@@ -64988,7 +64988,7 @@ arevalo
 briones
 1234567890k
 mamanjtm
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 sexygirls1
 g1nger
 jesus2007
@@ -65217,7 +65217,7 @@ lovely07
 teamjacob
 sexyblack
 theboys1
-ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
++
 310880
 060693
 luckygirl1
@@ -65902,7 +65902,7 @@ divorce2
 oscarwilde
 400025
 600094
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 shameless
 ganggang
 madison23
@@ -66330,7 +66330,7 @@ remark
 enjoi1
 hallo2
 said
-Ð¿Ñ€Ð¾ÑÑ‚Ð¾
+просто
 555555555555
 lethal
 georgia3
@@ -66412,7 +66412,7 @@ gemeni
 220979
 asdfghjkl7
 ashley27
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 mounia
 080188
 louanne
@@ -66782,7 +66782,7 @@ mayfair1
 interest
 29081983
 linkbuild
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 tokyo
 121415
 angels21
@@ -67786,7 +67786,7 @@ assmonkey
 bellamia
 01111987
 marcell1
-Ð¹Ñ„ÑÑ†Ñ‹Ñ‡
+йфяцыч
 coolpix
 beezy1
 10091980
@@ -67834,7 +67834,7 @@ cherrie
 topmost
 198101
 20152015
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½.
++.
 19101994
 cassie7
 shanks
@@ -68355,7 +68355,7 @@ rayyan
 lechuga
 24031993
 jacek1
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 dkflbdjcnjr
 usnavy1
 260180
@@ -68662,7 +68662,7 @@ roberto2
 jessie14
 28081982
 michael92
-ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
++
 110331rahili
 cloudy1
 leeds123
@@ -68935,7 +68935,7 @@ discipline
 may1994
 fredy
 thunder69
-ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½
+++
 ilovejosh!
 a321321
 playing1
@@ -68995,7 +68995,7 @@ turtle21
 02051978
 lebesgue
 johnathon
-ÑÐ»ÑŽÐ±Ð»ÑŽÑ‚ÐµÐ±Ñ
+ялюблютебя
 301178
 20031981
 erine!
@@ -69216,7 +69216,7 @@ flapjack1
 301079
 nokia73
 220778
-Ð¿Ð¾Ð»Ð¸Ð½Ð°
+полина
 lillypad
 06081983
 roger12
@@ -70881,7 +70881,7 @@ goyj2010
 fff111
 salina1
 swamiji
-ï¿½ï¿½ï¿½ï¿½
+
 22051981
 meena
 woof
@@ -70996,7 +70996,7 @@ jayden4
 10011995
 iiiii
 guadalupe2
-ï¿½ï¿½ï¿½ï¿½ï¿½123
+123
 aishiteru1
 0407
 27041994
@@ -71358,7 +71358,7 @@ jose12345
 wendy12
 granville
 diana10
-Ð»ÐµÐ½Ð¾Ñ‡ÐºÐ°
+леночка
 281178
 dummies
 11091981
@@ -71752,7 +71752,7 @@ skullcandy
 1sophie
 humanoid
 14725
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 140277
 happy2day
 unclesam
@@ -72228,7 +72228,7 @@ haohao
 vacuum
 muffie
 05091994
-ï¿½+ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½
+++
 123454321a
 daniel91
 bluenote
@@ -72452,7 +72452,7 @@ drizzt1
 suppandi
 alegna
 cmpunk1
-ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
++
 king4life
 nbvehrf
 butterfinger
@@ -72665,7 +72665,7 @@ desirae1
 180781
 planta
 Snickers1
-ÐºÐ¸Ñ€Ð¸Ð»Ð»
+кирилл
 qwerty1987
 ursula1
 vanness
@@ -73200,8 +73200,8 @@ ginger77
 8484
 07021980
 080684
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
+
 pigdog
 babybird
 150594
@@ -73436,7 +73436,7 @@ happy17
 15081993
 slovenija
 angel911
-Ð Ñ—Ð¡Ð‚Ð Ñ‘Ð Ð†Ð ÂµÐ¡â€š
+РїСЂРёРІРµС‚
 wumeiyun123
 jag123
 comanche1
@@ -73789,7 +73789,7 @@ babi12
 sexii123
 marinette
 bonus
-1234ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+1234
 140777
 3pointer
 1470
@@ -74075,7 +74075,7 @@ Schatz
 21051996
 dasha1998
 15051979
-Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…
+пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ
 flanagan
 My
 chance7
@@ -74229,7 +74229,7 @@ dindon
 spania
 asdewq123
 150179
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 tambok
 molly21
 010481
@@ -75220,7 +75220,7 @@ Xavier
 240179
 291987
 detroit2
-ÐºÐ°Ñ€Ð¸Ð½Ð°
+карина
 dpetrucco2
 1qaz2WSX
 roflrofl
@@ -75462,7 +75462,7 @@ picaso
 ancient
 520521
 25081981
-ÐºÐ°Ñ‚ÑŽÑˆÐ°
+катюша
 13467982
 02041977
 joseph25
@@ -76356,7 +76356,7 @@ ppppppppp
 300400
 passion69
 bundy
-Ð¼Ð°Ð¼ÑƒÐ»Ñ
+мамуля
 thomas87
 Lizzie
 pokesmot
@@ -76702,7 +76702,7 @@ jessi123
 198824
 020395
 Patches1
-ï¿½+ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½
+++
 frazer
 09061994
 1nothing
@@ -77086,7 +77086,7 @@ parris
 love48
 princess78
 SjiecJ1A9X
-Ð¾ÐºÑÐ°Ð½Ð°
+оксана
 classroom
 sadie13
 jesus00
@@ -77610,7 +77610,7 @@ fai
 221196
 04071980
 unity
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 march05
 proverbs1
 240280
@@ -78354,7 +78354,7 @@ cookie19
 josema
 srbija1
 moody
-123456Ð¹
+123456й
 160994
 jeff22
 a212121
@@ -78371,7 +78371,7 @@ scarface10
 3322
 fastback
 spongebob12
-ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
++
 400602
 espana1
 getrdone1
@@ -78813,7 +78813,7 @@ h1h1h1
 1913
 kinjal
 ibiza1
-Ð Ð…Ð Â°Ð¡â€šÐ Â°Ð¡â‚¬Ð Â°
+РЅР°С‚Р°С€Р°
 06041994
 19851025
 idonthave1
@@ -78974,7 +78974,7 @@ sharkey
 success01
 lola10
 dreams12
-ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½
+++
 fall2008
 baloch
 29061995
@@ -79634,7 +79634,7 @@ samsung4
 anna17
 niger1
 strikers
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½
++
 564321
 daddyyanke
 tinamarie
@@ -79855,7 +79855,7 @@ fevral
 blackveilb
 1422
 nadiya
-ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
++
 19881010
 cycling
 lovehurt
@@ -80105,7 +80105,7 @@ qweqwe11
 brayan1
 1234567897
 space3
-ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
++
 119
 xiaoyao
 19911992
@@ -80189,7 +80189,7 @@ trompeta
 stefania1
 sasuke23
 071987
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 198809
 friend7
 magnet1
@@ -80429,7 +80429,7 @@ july1994
 181295
 10121977
 15061979
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½-+ï¿½ï¿½ï¿½ï¿½
+--+
 magic01
 171178
 199102
@@ -80469,7 +80469,7 @@ lia123
 grind1
 16121612
 cathie
-Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…
+пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ
 parrotlet
 dinosaurs
 HarryPotter
@@ -80482,7 +80482,7 @@ animals12
 maples
 16041980
 determined
-Ñ€Ð°Ð½ÐµÑ‚ÐºÐ¸
+ранетки
 dokken
 020379
 7550055
@@ -80576,7 +80576,7 @@ basbas
 pascua
 2bFiy28byL
 uzbekistan
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 disney!
 houston5
 tigger68
@@ -80744,7 +80744,7 @@ password35
 14041977
 24011981
 23071979
-Ð²ÐµÑ€Ð¾Ð½Ð¸ÐºÐ°
+вероника
 09061982
 irule123
 chris44
@@ -80950,7 +80950,7 @@ karito
 fight123
 fever
 nanny123
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 derbeder
 creature1
 vinay
@@ -81408,7 +81408,7 @@ velocity1
 28111982
 annabella1
 club
-ÐºÑ€Ð°ÑÐ¾Ñ‚ÐºÐ°
+красотка
 romeo11
 070594
 3e4r5t6y
@@ -81457,7 +81457,7 @@ lilac
 270795
 gracie!
 841010
-ï¿½ï¿½ï¿½
+
 supersport
 sex111
 america18
@@ -81498,7 +81498,7 @@ omnislash
 cartman2
 liyana
 4gotten
-ÑÑ‡Ð°ÑÑ‚ÑŒÐµ
+счастье
 lanier
 cacat123
 seedorf
@@ -81666,7 +81666,7 @@ cagney
 bulldogs7
 x1234567
 Kinder
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½
++
 313
 07021993
 73737373
@@ -82207,7 +82207,7 @@ playgirl69
 think456
 09091995
 vienna1
-Ð½Ðµ
+не
 jawbreaker
 crayons
 197319
@@ -82856,7 +82856,7 @@ paintball4
 weedweed1
 BLCKD_SA_UNPAIDFEE_OCT06
 kittens3
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 lucette
 060893
 27041980
@@ -83866,7 +83866,7 @@ gabriel15
 down
 13111978
 pimaout
-Ñ‚ÐµÐ»ÐµÑ„Ð¾Ð½
+телефон
 aaa111aaa
 monkey777
 060897
@@ -84121,7 +84121,7 @@ blazed1
 ballin01
 04071995
 monique11
-ï¿½
+
 swag123
 june1983
 258963147
@@ -84259,7 +84259,7 @@ crazychick
 internet.
 fate
 mario69
-ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½
++++++++++++++++
 praktikum
 28111993
 jessie15
@@ -84421,7 +84421,7 @@ pimpc1
 cody69
 jonas14
 cpPzfRC933
-ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½
++
 250795
 291294
 toyota11
@@ -84618,7 +84618,7 @@ gerard12
 marajade
 blocked
 268268
-ï¿½+ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+++
 nfyznfyz
 271077
 13579135
@@ -84659,7 +84659,7 @@ florida8
 19861123
 suzette1
 dima1999
-ÐºÐ¾Ñ‚ÐµÐ½Ð¾Ðº
+котенок
 110297
 311093
 casper4
@@ -84912,7 +84912,7 @@ bahadur
 macias
 holly5
 walker01
-ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
++
 140995
 victoria.
 4649
@@ -85081,11 +85081,11 @@ anything2
 Ryan
 oioioi1
 1469
-Ð¹Ñ†ÑƒÐºÐµÐ½Ð³
+йцукенг
 Horses
 131195
 100375
-Ð½ÐµÐ½Ð°Ð²Ð¸Ð¶Ñƒ
+ненавижу
 poiu1234
 1235678
 27091994
@@ -86448,7 +86448,7 @@ hardcore7
 reserved
 redneck08
 robert30
-ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½
+++++++++++++++++++++
 ye123456
 hotie1
 1530
@@ -86985,7 +86985,7 @@ pageup
 sexybeast!
 suhasini
 redlight1
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½
+++
 goldengate
 010896
 dates
@@ -87835,7 +87835,7 @@ texas06
 inferno666
 forzalecce
 Potter
-ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
++
 nikki06
 2gether4ever
 zaqwert
@@ -87928,7 +87928,7 @@ jaguar12
 159159a
 Stacey
 ilovechad1
-Ð¼Ð°Ñ€ÑƒÑÑ
+маруся
 gala
 lucy07
 poopoo3
@@ -88141,7 +88141,7 @@ thenewme
 201296
 junior28
 zoosk2010
-ï¿½ï¿½ï¿½+ï¿½+ï¿½ï¿½ï¿½
+++
 20031996
 ghjcnjrdfif
 180378
@@ -88187,7 +88187,7 @@ troll0
 mysp4ce
 071294
 malenka
-Ð Ñ˜Ð Â°Ð Ñ”Ð¡ÐƒÐ Ñ‘Ð Ñ˜
+РјР°РєСЃРёРј
 20081995
 120997
 04121980
@@ -89501,7 +89501,7 @@ mushka
 191293
 cocktail1
 caserta
-Ð Ñ˜Ð Â°Ð¡Ð‚Ð Ñ‘Ð Ð…Ð Â°
+РјР°СЂРёРЅР°
 diva1234
 kiss23
 20071977
@@ -89668,7 +89668,7 @@ kaycie1
 lolli
 winters1
 2022
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 27021994
 29011981
 surf12
@@ -89872,7 +89872,7 @@ varghese
 shalom7
 palencia
 Stephanie1
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 anna24
 brian6
 02021972
@@ -90767,7 +90767,7 @@ shambala
 fgh123
 mobius1
 jodie123
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½
+++
 single2010
 igetmoney2
 disney13
@@ -91413,7 +91413,7 @@ spence1
 1hotbitch
 160378
 elieli
-1ï¿½ï¿½ï¿½ï¿½ï¿½2ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+12
 sugar69
 030695
 homegirl1
@@ -91505,7 +91505,7 @@ chicony
 connolly
 newport3
 azules
-12345ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+12345
 carita
 ilovejenny
 ladida
@@ -91619,7 +91619,7 @@ hitchcock
 lacrosse9
 skippy01
 dct:
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
++
 hardcore4
 psp71835
 cangrejo
@@ -91746,7 +91746,7 @@ atienza
 krusty1
 happylove
 velosiped
-Ð¿Ñ€Ð¸Ð²ÐµÑ‚Ð¸Ðº
+приветик
 031275
 wayne13
 gxtkrf
@@ -91805,7 +91805,7 @@ mysterio619
 jessie07
 a420420
 qavcx411
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½
++
 zxcv12345
 dimples2
 men123
@@ -92368,7 +92368,7 @@ brigida
 reynold
 fuckemall
 Joanna
-123456ï¿½ï¿½
+123456
 07071978
 crypto
 bandits1
@@ -92429,7 +92429,7 @@ darkmanx
 180977
 july2005
 VALERIE
-ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½
++
 cupcake09
 lynn09
 sydney22
@@ -92447,12 +92447,12 @@ asdfg11
 kittens12
 051178
 xyxy159753
-ÑÐ°ÑˆÐµÐ½ÑŒÐºÐ°
+сашенька
 amherst
 badmus
 encarta
 troopers
-Ñ€ÑƒÑÐ»Ð°Ð½
+руслан
 elliemae1
 julian14
 4weaxQ642E
@@ -92769,7 +92769,7 @@ mentiras
 daisy06
 youness
 serena12
-ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
++
 030676
 10011996
 softball02
@@ -92978,7 +92978,7 @@ suckmyballs
 qingqing
 22031976
 fishing!
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 downloads
 gatogato
 goodpussy
@@ -93753,7 +93753,7 @@ crystal09
 walker11
 bluerose1
 cheater!
-Ð¸Ñ€Ð¸ÑˆÐºÐ°
+иришка
 mario4
 13071979
 j121212
@@ -94549,7 +94549,7 @@ smokey8
 junior33
 33221100
 inlovewith
-Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…Ð¿Ñ—Ð…
+пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ
 yelhsa
 babydoll7
 041296
@@ -94690,7 +94690,7 @@ honey27
 110474
 jDnazp972X
 munchen
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 tobby1
 loverboy3
 210275
@@ -95023,7 +95023,7 @@ tylerd
 insect
 olivia16
 storm11
-ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½
++
 12101975
 carson2
 wolf01
@@ -95039,7 +95039,7 @@ veczhec
 rattle
 Diana
 170696
-Ð½Ð°Ð´ÐµÐ¶Ð´Ð°
+надежда
 alone4ever
 742617000027
 harold123
@@ -95107,7 +95107,7 @@ froggy01
 121600
 vin123
 navara
-ï¿½+ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½+ï¿½
++++
 panther9
 trener
 28101979
@@ -95450,7 +95450,7 @@ owner@hr.com
 rocket69
 cordova1
 campanile
-Ð¼Ð°ÐºÑÐ¸Ð¼ÐºÐ°
+максимка
 marist
 1366
 biggie2
@@ -95713,7 +95713,7 @@ brown22
 scrappy12
 roro123
 train123
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+
 130013
 hiphop5
 jumpoff1
@@ -97313,7 +97313,7 @@ logan23
 1georgia
 alskdjfhg1
 Maureen
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½
++
 bryan3
 bryan23
 phoebe12
@@ -97930,7 +97930,7 @@ lixiang
 mario8
 25032503
 turtle9
-Ð¹Ñ„ÑÑ†Ñ‹Ñ‡ÑƒÐ²Ñ
+йфяцычувс
 azbest777
 madonna2
 220011
@@ -98247,7 +98247,7 @@ bassoon1
 smiley10
 looser123
 Sergei
-ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
++
 aka
 kaila
 czarny
@@ -98742,7 +98742,7 @@ muffin6
 gfhjkmm
 lovelove7
 grandmom
-ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½
++
 rawrrawr
 twisted2
 element14
@@ -99060,7 +99060,7 @@ kokito
 28051996
 1sunday
 flex
-ï¿½ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
++
 poiuyt5
 sniper69
 gracie03
@@ -99207,7 +99207,7 @@ fifnfy
 super88
 27101977
 vwpassat
-ï¿½+ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½+
+++
 aol
 gizzy
 hotgurl


### PR DESCRIPTION
<!--- IMPORTANT --->
<!--- Please make sure you've checked the CONTRIBUTING.md before creating a pull-request: https://github.com/danielmiessler/SecLists/blob/master/CONTRIBUTING.md -->
<!--- IMPORTANT --->

**Purpose of pull request**
Fix the encoding of the NCSC 100k most used passwords list
<!--- Tell us what made you decide to open a pull request. --->
<!--- If you added a wordlist, describe what it could be used for --->

**Source**
This file is no longer present on the NCSC website so it was grabbed from the latest copy in The National Archives - https://webarchive.nationalarchives.gov.uk/ukgwa/20241220133328/https://www.ncsc.gov.uk/static-assets/documents/PwnedPasswordsTop100k.txt

<!--- Put/link the source here. -->

**Additional context**
<!--- Add any other context about the problem/missing feature that you are fixing/solving here. -->
<!--- Tag the issue here if applicable. -->
