### PR TITLE
Update curl-protocols.txt

### DIFF
--- a/Miscellaneous/curl-protocols.txt
+++ b/Miscellaneous/curl-protocols.txt
@@ -3,12 +3,14 @@ file
 ftp
 ftps
 gopher
+gophers
 http
 https
 imap
 imaps
 ldap
 ldaps
+mqtt
 pop3
 pop3s
 rtmp
@@ -26,3 +28,5 @@ smtp
 smtps
 telnet
 tftp
+ws
+wss


### PR DESCRIPTION
**Purpose of pull request**
The curl protocols list `curl-protocols.txt` is outdated by 8 years. I was recently using it in an engagement and needed a more up to date list. Decided to share it here. I took the list from the curl manpage and merged it with the current list.

**Source**
[Curl manpage](https://curl.se/docs/manpage.html)
