### PR TITLE
Fix wordlist-updater_default-passwords.yml

### DIFF
--- a/.github/workflows/wordlist-updater_default-passwords.yml
+++ b/.github/workflows/wordlist-updater_default-passwords.yml
@@ -29,7 +29,7 @@ jobs:
           fi
       - name: Generate default-passwords.txt
         run: |
-          ./csvq -N -f FIXED 'select Password from `Passwords/Default-Credentials/default-passwords.csv`' > Passwords/Default-Credentials/default-passwords.txt
+          ./csvq -N -f TSV 'select Password from `Passwords/Default-Credentials/default-passwords.csv`' > Passwords/Default-Credentials/default-passwords.txt
       - name: Switching from HTTPS to SSH
         run: git remote set-url origin git@github.com:${{ github.repository }}.git
       - name: Check for changes

--- a/.github/workflows/wordlist-updater_default-passwords.yml
+++ b/.github/workflows/wordlist-updater_default-passwords.yml
@@ -29,7 +29,7 @@ jobs:
           fi
       - name: Generate default-passwords.txt
         run: |
-          ./csvq -N -f TSV 'select Password from `Passwords/Default-Credentials/default-passwords.csv`' > Passwords/Default-Credentials/default-passwords.txt
+          ./csvq -N -f CSV 'select Password from `Passwords/Default-Credentials/default-passwords.csv`' > Passwords/Default-Credentials/default-passwords.txt
       - name: Switching from HTTPS to SSH
         run: git remote set-url origin git@github.com:${{ github.repository }}.git
       - name: Check for changes


### PR DESCRIPTION
<!--- IMPORTANT --->
<!--- Please make sure you've checked the CONTRIBUTING.md before creating a pull-request: https://github.com/danielmiessler/SecLists/blob/master/CONTRIBUTING.md -->
<!--- IMPORTANT --->

**Purpose of pull request**
<!--- Tell us what made you decide to open a pull request. --->
<!--- If you added a wordlist, describe what it could be used for --->

The `FIXED` import format in csvq pads the resulting `default-passwords.txt` with trailing spaces in each line. I assume this was not intended.