### PR TITLE
feat(wordlist): added entries to "SAP-NetWeaver.txt"

### DIFF
--- a/Discovery/Web-Content/SAP-NetWeaver.txt
+++ b/Discovery/Web-Content/SAP-NetWeaver.txt
@@ -184,6 +184,8 @@ sap/IStest
 sap/admin
 sap/admin/default.html
 sap/admin/index.html
+sap/admin/public/default.html
+sap/admin/public/index.html
 sap/ap
 sap/bc
 sap/bc/


### PR DESCRIPTION
Observed "/sap/admin/public/default.html" and "/sap/admin/public/index.html" in the wild. The index.hml page might be accessible unauthenticated.

<!--- IMPORTANT --->
<!--- Please make sure you've checked the CONTRIBUTING.md before creating a pull-request: https://github.com/danielmiessler/SecLists/blob/master/CONTRIBUTING.md -->
<!--- IMPORTANT --->

**Purpose of pull request**
I observed these paths in the wild in a SAP NetWeaver instance:
- `/sap/admin/public/default.html`
- `/sap/admin/public/index.html`
The index.html page was accessible **_without authentication._** I would have missed it if I had not noticed the link below.

**Source**
[Some infos about SAP Security Note 2258786 | insinuator.net](https://insinuator.net/2016/06/some-details-about-sap-security-note-2258786/)

**Additional context**
Just wanted to say thank you to the maintainers of this great resource!