### PR TITLE
Add 'rdweb' to common.txt

### DIFF
--- a/Discovery/Web-Content/common.txt
+++ b/Discovery/Web-Content/common.txt
@@ -3447,6 +3447,7 @@ rcs
 rct
 rd
 rdf
+rdweb
 read
 reader
 readfile


### PR DESCRIPTION
**Purpose of pull request**
Insert "rdweb" into the middle of common.txt. During web directory brute-forcing (especially in internal or AD environments), Microsoft's default Remote Desktop Web Access virtual directory "/rdweb" is a high-value target. Adding it to the middle of the list keeps the file alphabetically ordered and improves hit-rate without manual dictionary tweaks.

**Source**
Microsoft official documentation and repeated red-team experience:
- Default RD Web Access URL is https://\<server\>/rdweb
- Observed frequently in internal assessments; placing it alphabetically among existing entries keeps the list tidy and scanner-friendly.

**Additional context**
No open issue; minor enhancement. File remains UTF-8, no duplicates or trailing whitespace introduced.