### PR TITLE
feat(names.txt): adds missing common Hispanic and Southern Europe names

### DIFF
--- a/Usernames/Names/names.txt
+++ b/Usernames/Names/names.txt
@@ -188,6 +188,7 @@ aisling
 aislinn
 aislynn
 aitana
+aithor
 aitor
 ajay
 ajit
@@ -654,6 +655,7 @@ antonina
 antonio
 anton-phuoc
 antony
+anuar
 anuja
 anup
 anurag
@@ -1348,7 +1350,9 @@ brady
 braeden
 braelyn
 brahmananda
+brahim
 braiden
+brais
 bram
 bran
 brana
@@ -2507,6 +2511,7 @@ david
 davida
 davin
 davina
+davinia
 davinder
 davine
 davion
@@ -3225,6 +3230,7 @@ encarna
 encarnación
 ende
 ender
+endrick
 eneko
 eng
 engbert
@@ -3272,6 +3278,7 @@ erkan
 erle
 erlene
 erma
+ermenegildo
 ermengarde
 ermentrude
 ermina
@@ -3522,6 +3529,7 @@ ferdinand
 ferdinanda
 ferdinande
 fereidoon
+ferland
 fergal
 fergus
 feridoun
@@ -3766,6 +3774,7 @@ gaspar
 gaston
 gates
 gateway
+gavi
 gavin
 gavira
 gavra
@@ -4571,6 +4580,7 @@ ingres
 ingrid
 ingunna
 inigo
+iñigo
 inm
 inma
 inmaculada
@@ -4585,6 +4595,7 @@ iona
 iormina
 ira
 iraj
+iratxe
 irc
 ireland
 irena
@@ -5212,6 +5223,7 @@ juanjo
 juanjosé
 juanma
 juanmanuel
+juanramon
 jud
 judah
 judas
@@ -5866,6 +5878,7 @@ lalit
 lalitha
 lamar
 lambert
+lamine
 lamont
 lan
 lana
@@ -6398,6 +6411,8 @@ lusa
 luther
 luuk
 luz
+luzdi
+luzdivina
 lyda
 lydda-june
 lydia
@@ -6616,6 +6631,7 @@ manny
 manohar
 manoj
 manon
+manolo
 manou
 manouch
 mansukha
@@ -7364,6 +7380,7 @@ myrtille
 myrtle
 mysore
 nabil
+nacho
 nachum
 nad
 nada
@@ -7882,7 +7899,6 @@ pablo
 pac
 pacific
 paco
-pacopepe
 paddy
 padma
 padraig
@@ -8227,6 +8243,7 @@ quiana
 quincy
 quinlan
 quinn
+quico
 quino
 quinta
 quintana
@@ -10351,6 +10368,7 @@ westin
 weston
 whitfield
 whitney
+wiam
 wiebe
 wiebren
 wiele
@@ -10523,6 +10541,7 @@ ylaine
 ynes
 ynez
 yodha
+yoel
 yogesh
 yogi
 yokan
@@ -10545,6 +10564,7 @@ yoshi
 yoshiaki
 yoshiko
 yoshimitsu
+yosef
 yosuf
 youji
 young-june
@@ -10661,6 +10681,7 @@ zendaya
 zenia
 zenon
 zeph
+zeus
 zere
 zero
 zeth
@@ -10703,6 +10724,7 @@ zsazsa
 zuben
 zula
 zulema
+zuleyma
 zulfikar
 zuri
 zuriel


### PR DESCRIPTION
### Adds common Hispanic and Southern Europe names
I was developing a script to search for names in metadata and found that some Hispanic/Spanish names were missing.

**Propose of pull request**

- Common Hispanic names and regional variations (Galician and Basque) were added: aithor, anuar, brais, brahim, davinia, endrick, ermenegildo, ferland, gavi, inigo, iñigo, iratxe, juanramon, lamine, luzdi, luzdivina, manolo, nacho, quico, wiam, yoel, yosef, zeus, zulema, zuleyma.

- Some of the entries include Arabic or African names that are increasingly popular in Southern Europe. Also modern names that are trendy.

> **Additional context**
> During the process, I found and deleted pacopepe. This entry seemed to be a mistake or a concatenation of two separate names. Even as a compound name, it wouldn't be spelled that way in a standard wordlist. It is not a legitimate single name.
>
> IMPORTANT: I added Iñigo considering 'ñ' is allowed in the list, otherwise delete it.