### PR TITLE
feat(wordlist): Added "ai-infrastructure.txt" by CyberDesserts

### DIFF
--- a/Discovery/Web-Content/README.md
+++ b/Discovery/Web-Content/README.md
@@ -105,3 +105,12 @@ Sources:
 * [Spring Boot MCP Server Boot Starters](https://docs.spring.io/spring-ai/reference/api/mcp/mcp-server-boot-starter-docs.html).
 * [Official Python SDK for Model Context Protocol servers and clients](https://github.com/modelcontextprotocol/python-sdk).
 
+## ai-infrastructure.txt
+
+Use for: Discovering exposed AI/ML model-serving and orchestration endpoints (Ollama, OpenAI-compatible APIs, Ray, vLLM/SGLang) during reconnaissance of AI infrastructure.
+
+Date updated: May 26, 2026
+
+Source: https://blog.cyberdesserts.com/
+Reference: https://blog.cyberdesserts.com/ai-infrastructure-scanning-research/
+

--- a/Discovery/Web-Content/ai-infrastructure.txt
+++ b/Discovery/Web-Content/ai-infrastructure.txt
@@ -1,0 +1,13 @@
+api/chat
+api/cluster_status
+api/generate
+api/ps
+api/show
+api/tags
+api/v1/credentials
+api/v1/models
+update_weights_from_tensor
+v1/chat/completions
+v1/completions
+v1/embeddings
+v1/models


### PR DESCRIPTION

**Purpose of pull request**
Adds a new wordlist, ai-infrastructure.txt, covering AI and ML model-serving and orchestration API endpoints (Ollama, OpenAI-compatible APIs, Ray, vLLM/SGLang). Intended for discovering exposed AI infrastructure during reconnaissance and content discovery. Complements the existing mcp-server.txt by covering the model-serving API surface rather than MCP. Deduplicated, sorted, and no leading slashes per CONTRIBUTING.md.

**Source**
The endpoints were observed during honeypot reconnaissance of exposed AI infrastructure. Methodology and findings: https://blog.cyberdesserts.com/ai-infrastructure-scanning-research/

**Additional context**
Generic endpoints that also appeared in the data (for example metrics, health, docs, openapi.json) were deliberately excluded to avoid false positives on non-AI FastAPI applications, keeping the list focused on AI-distinctive paths.
