### PR TITLE
Add OpenID Shared Signals Framework metadata endpoint

### DIFF
--- a/Discovery/Web-Content/common.txt
+++ b/Discovery/Web-Content/common.txt
@@ -87,6 +87,7 @@
 .well-known/repute-template
 .well-known/resourcesync
 .well-known/security.txt
+.well-known/ssf-configuration
 .well-known/humans.txt
 .well-known/stun-key
 .well-known/thread


### PR DESCRIPTION
# Purpose of pull request

Hello,

This PR add the endpoint `/.well-known/ssf-configuration` to the `Discovery/Web-Content/common.txt` dictionary.

This file is the metadata file for [OpenID Shared Signals Framework Specification 1.0](https://openid.net/specs/openid-sharedsignals-framework-1_0.html).

# Sources 

The endpoint came from the following sources:

* https://openid.net/specs/openid-sharedsignals-framework-1_0.html#section-7.2
* https://developer.sailpoint.com/docs/api/v2025/get-ssf-configuration/
* https://developer.okta.com/docs/guides/configure-ssf-receiver/main/


# Additional context

I discovered this endpoint during this conference:

* https://m.devoxx.com/events/voxxedlu2026/talks/5463/details
