### PR TITLE
feat: template engine identification

### DIFF
--- a/Fuzzing/README.md
+++ b/Fuzzing/README.md
@@ -24,3 +24,8 @@ Source: [JBroFuzz](https://sourceforge.net/projects/jbrofuzz/)
 ## fully-qualified-java-classes.txt
 
 Use for: Fuzzing URL parameters in **web applications** to test for **deserialisation** and **type confusion** vulnerabilities.
+
+## template-engines-identification.txt
+
+Use for: Indentifying the template engine of a web application based on the reflected values of the items of this list. Based on the substitutions, the template can be identified using this [graph](https://hacktricks.wiki/en/pentesting-web/ssti-server-side-template-injection/index.html#identification-by-payloads)
+

--- a/Fuzzing/template-engines-identification.txt
+++ b/Fuzzing/template-engines-identification.txt
@@ -1,0 +1,24 @@
+D{{="O"}}T
+P#{XXXXX}ug
+Thym[[${session}]]eleaf
+Dus{XXXXXXX}tjs
+Sm{"ar"}ty
+La{var $X="tt"}{$X}e
+#set($X="Velo")#set($Y="city")$X$Y
+Underscore OR<%"XXXXXXXXXX"%>Ejs
+E<%="j"_%>s
+This{{printf "is "}}GO
+Haml#{"OR"}Slim
+Erb<%="OR Erubi OR"%>Erubis
+Must{{Context.lookup}}ache
+Handlebars OR Hogan{{XXXXXXX}} OR Pystache
+{{#if 0 IncludeZero=true}}Handlebars{{/if}}
+Mako${"OR Chameleon OR "}Cheetah
+Freemakers${" OR "}Groovy
+Liquid AND Blade OR Twig {{" AND Jinja2 OR Bottle OR Tornado OR Django AND "}}Nunjucks OR Twig OR Vue
+{{|reverse}}
+{{|wordcount}}
+{{-Comment-}}
+{{ "<h1>Django OR Jinja</h1>"|striptags }}
+Djan{{ Jinja2.Django }}go
+Torn{% comment %}ado


### PR DESCRIPTION
**Purpose of pull request**
Provide a list to automate template engine identification by reflected content

**Source**
[https://hacktricks.wiki/en/pentesting-web/ssti-server-side-template-injection/index.html#identification-by-payloads](https://hacktricks.wiki/en/pentesting-web/ssti-server-side-template-injection/index.html#identification-by-payloads)

**Additional context**
I hesitated between enriching `Fuzzing/template-engines-expression.txt ` and create this list. Though their goals are similar, the current list is ought to be used with [this algo](https://hacktricks.wiki/en/pentesting-web/ssti-server-side-template-injection/index.html#identification-by-payloads) in mind for it to make sense. Let me know if you prefer to merge it with the existing. 

Best