### PR TITLE
Add '66668888' to common credentials list

### DIFF
--- a/Passwords/Common-Credentials/10k-most-common.txt
+++ b/Passwords/Common-Credentials/10k-most-common.txt
@@ -1895,6 +1895,7 @@ jumper
 margaret
 archie
 66666666
+66668888
 charlott
 forget
 qwertz


### PR DESCRIPTION
**Purpose of pull request**
Adds the password "66668888" to the common credentials wordlist. It follows the same repdigit/lucky-number pattern as the existing "66666666" and "88888888" entries and is a commonly used WiFi password in China (see issue #1343).

**Source**
Requested in issue #1343: https://github.com/danielmiessler/SecLists/issues/1343

**Additional context**
Placed adjacent to the existing "66666666" entry in 10k-most-common.txt.

Closes #1343

<img width="2692" height="1662" alt="70113" src="https://github.com/user-attachments/assets/44422b9a-b448-4673-8166-b7a98a6063d7" />
